### PR TITLE
Ajuste na recuperação de vínculo de alunos

### DIFF
--- a/app/models/student_enrollment.rb
+++ b/app/models/student_enrollment.rb
@@ -112,9 +112,9 @@ class StudentEnrollment < ActiveRecord::Base
                                    exam_rule
 
       classroom_grade.student_enrollment_classrooms.each do |student_enrollment_classroom|
-        differentiated = student_enrollment_classroom.student_enrollment
-                                                     .student
-                                                     .uses_differentiated_exam_rule
+        
+        differentiated = student_enrollment_classroom.student_enrollment&.student&.uses_differentiated_exam_rule
+        
         if differentiated && differentiated_exam_rule
           students_by_opinion_type << student_enrollment_classroom.id
         elsif exam_rule && !differentiated


### PR DESCRIPTION
Ajustando a recuperação do vínculo de alunos na turma. Estava causando erro ao abrir avaliações descritivas

## Descrição
Forçando a verificação de presença de vínculo de matrícula para os alunos

## Contexto e motivação
Não estava abrindo avaliações descritivas. Ao tentar criar uma nova avaliação descritiva o sistema redirecionava para a página inicial e mostrava uma mensagem genérica de erro.

Issue https://github.com/portabilis/i-diario/issues/102. (#102)

## Tipos de alterações
- ✅ Correção de bugs (Não quebra outras funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue o style guide. **[REQUIRED]**