### PR TITLE
Feature/relatorios medias

### DIFF
--- a/app/assets/javascripts/views/exam_record_report/form.js
+++ b/app/assets/javascripts/views/exam_record_report/form.js
@@ -125,6 +125,21 @@ $(document).ready(function () {
     flashMessages.error('Ocorreu um erro ao buscar as disciplinas da turma selecionada.');
   };
 
+  // Controla a exibição do campo de etapa baseado no tipo de relatório
+  $('#report_type_select').on('change', function() {
+    var reportType = $(this).val();
+    if (reportType === 'all_steps_averages') {
+      $('#step_selection').hide();
+      $('#step_selection input, #step_selection select').prop('required', false);
+    } else {
+      $('#step_selection').show();
+      $('#step_selection input, #step_selection select').prop('required', true);
+    }
+  });
+
+  // Executa na carga da página
+  $('#report_type_select').trigger('change');
+
   $('form').submit(function (event) {
     var tempoEspera = 2000;
 

--- a/app/assets/javascripts/views/exam_record_report/form.js
+++ b/app/assets/javascripts/views/exam_record_report/form.js
@@ -126,7 +126,7 @@ $(document).ready(function () {
   };
 
   // Controla a exibição do campo de etapa baseado no tipo de relatório
-  $('#report_type_select').on('change', function() {
+  $('.report_type_radio').on('change', function() {
     var reportType = $(this).val();
     if (reportType === 'all_steps_averages') {
       $('#step_selection').hide();
@@ -138,7 +138,11 @@ $(document).ready(function () {
   });
 
   // Executa na carga da página
-  $('#report_type_select').trigger('change');
+  // Se nenhum estiver selecionado, seleciona "Médias de todas as etapas" por padrão
+  if (!$('.report_type_radio:checked').length) {
+    $('#report_type_all_steps_averages').prop('checked', true);
+  }
+  $('.report_type_radio:checked').trigger('change');
 
   $('form').submit(function (event) {
     var tempoEspera = 2000;

--- a/app/controllers/attendance_record_report_by_students_controller.rb
+++ b/app/controllers/attendance_record_report_by_students_controller.rb
@@ -41,6 +41,13 @@ class AttendanceRecordReportByStudentsController < ApplicationController
 
     set_options_by_user
     render :form
+  rescue StandardError => e
+    flash.now[:alert] = "Erro ao gerar relatório: #{e.message}"
+
+    @attendance_record_report_by_student_form.school_calendar_year = current_school_year
+
+    set_options_by_user
+    render :form
   end
 
   def fetch_period_by_classroom

--- a/app/controllers/conceptual_exams_controller.rb
+++ b/app/controllers/conceptual_exams_controller.rb
@@ -15,6 +15,7 @@ class ConceptualExamsController < ApplicationController
     set_options_by_user
 
     @conceptual_exams = fetch_conceptual_exams
+    @only_one_conceptual_avaliation = Rails.application.secrets.only_one_conceptual_avaliation.present? && Rails.application.secrets.only_one_conceptual_avaliation
 
     check_status_and_step(step_id, status)
 

--- a/app/controllers/exam_record_report_controller.rb
+++ b/app/controllers/exam_record_report_controller.rb
@@ -140,14 +140,33 @@ class ExamRecordReportController < ApplicationController
       show_inactive: false
     ).student_enrollments
 
-    ExamRecordAllStepsAveragesReport.build(
-      current_entity_configuration,
-      current_teacher,
-      current_school_year,
-      classroom,
-      Discipline.find(@exam_record_report_form.discipline_id),
-      steps,
-      students_enrollments
-    )
+    # Ler configuração de recuperação semestral
+    # Se não estiver definido, considerar como false
+    semestral_recovery = Rails.application.secrets.try(:semestral_recovery) || 
+                         Rails.application.secrets.try(:SEMESTRAL_RECOVERY) || 
+                         false
+
+    # Decidir qual relatório usar baseado na configuração
+    if semestral_recovery
+      ExamRecordAllStepsAveragesReport.build(
+        current_entity_configuration,
+        current_teacher,
+        current_school_year,
+        classroom,
+        Discipline.find(@exam_record_report_form.discipline_id),
+        steps,
+        students_enrollments
+      )
+    else
+      ExamRecordAllStepsAveragesAdaptiveReport.build(
+        current_entity_configuration,
+        current_teacher,
+        current_school_year,
+        classroom,
+        Discipline.find(@exam_record_report_form.discipline_id),
+        steps,
+        students_enrollments
+      )
+    end
   end
 end

--- a/app/controllers/exam_record_report_controller.rb
+++ b/app/controllers/exam_record_report_controller.rb
@@ -19,7 +19,11 @@ class ExamRecordReportController < ApplicationController
     set_school_calendars
 
     if @exam_record_report_form.valid?
-      exam_record_report = @school_calendar_classroom_steps.any? ? build_by_classroom_steps : build_by_school_steps
+      if @exam_record_report_form.report_type == 'all_steps_averages'
+        exam_record_report = build_all_steps_averages_report
+      else
+        exam_record_report = @school_calendar_classroom_steps.any? ? build_by_classroom_steps : build_by_school_steps
+      end
       send_pdf(t("routes.exam_record_report"), exam_record_report.render)
     else
       set_options_by_user
@@ -47,7 +51,8 @@ class ExamRecordReportController < ApplicationController
                                                     :classroom_id,
                                                     :discipline_id,
                                                     :school_calendar_step_id,
-                                                    :school_calendar_classroom_step_id)
+                                                    :school_calendar_classroom_step_id,
+                                                    :report_type)
   end
 
   def build_by_school_steps
@@ -118,5 +123,31 @@ class ExamRecordReportController < ApplicationController
 
     classroom_id = @exam_record_report_form.classroom_id
     @disciplines = @disciplines.by_classroom_id(classroom_id).not_descriptor
+  end
+
+  def build_all_steps_averages_report
+    classroom = Classroom.find(@exam_record_report_form.classroom_id)
+    steps_fetcher = StepsFetcher.new(classroom)
+    steps = steps_fetcher.steps
+    
+    students_enrollments = StudentEnrollmentsList.new(
+      classroom: @exam_record_report_form.classroom_id,
+      discipline: @exam_record_report_form.discipline_id,
+      start_at: steps.first&.start_at,
+      end_at: steps.last&.end_at,
+      score_type: StudentEnrollmentScoreTypeFilters::NUMERIC,
+      search_type: :by_date_range,
+      show_inactive: false
+    ).student_enrollments
+
+    ExamRecordAllStepsAveragesReport.build(
+      current_entity_configuration,
+      current_teacher,
+      current_school_year,
+      classroom,
+      Discipline.find(@exam_record_report_form.discipline_id),
+      steps,
+      students_enrollments
+    )
   end
 end

--- a/app/forms/exam_record_report_form.rb
+++ b/app/forms/exam_record_report_form.rb
@@ -17,7 +17,7 @@ class ExamRecordReportForm
   validate :must_have_daily_notes, unless: -> { report_type == 'all_steps_averages' }
   
   def report_type
-    @report_type ||= 'step_evaluations'
+    @report_type ||= 'all_steps_averages'
   end
 
   def daily_notes

--- a/app/forms/exam_record_report_form.rb
+++ b/app/forms/exam_record_report_form.rb
@@ -5,15 +5,20 @@ class ExamRecordReportForm
                 :classroom_id,
                 :discipline_id,
                 :school_calendar_step_id,
-                :school_calendar_classroom_step_id
+                :school_calendar_classroom_step_id,
+                :report_type
 
   validates :unity_id,      presence: true
   validates :classroom_id,  presence: true
   validates :discipline_id, presence: true
-  validates :school_calendar_step_id, presence: true, unless: :school_calendar_classroom_step_id
-  validates :school_calendar_classroom_step_id, presence: true, unless: :school_calendar_step_id
+  validates :school_calendar_step_id, presence: true, unless: -> { school_calendar_classroom_step_id.present? || report_type == 'all_steps_averages' }
+  validates :school_calendar_classroom_step_id, presence: true, unless: -> { school_calendar_step_id.present? || report_type == 'all_steps_averages' }
 
-  validate :must_have_daily_notes
+  validate :must_have_daily_notes, unless: -> { report_type == 'all_steps_averages' }
+  
+  def report_type
+    @report_type ||= 'step_evaluations'
+  end
 
   def daily_notes
     return unless step

--- a/app/models/knowledge_area_content_record.rb
+++ b/app/models/knowledge_area_content_record.rb
@@ -86,22 +86,28 @@ class KnowledgeAreaContentRecord < ActiveRecord::Base
 
     base_query = base_query.where.not(id: id) if persisted?
 
-    # Para cada área de conhecimento, verifica se há registros que a contêm
-    # Depois verifica se algum desses registros tem exatamente as mesmas áreas
-    matching_records = base_query.joins(:knowledge_areas)
+    # Busca registros que contêm todas as áreas de conhecimento especificadas
+    # Usa uma subquery mais segura para evitar problemas com GROUP BY
+    matching_records = base_query
+      .joins(:knowledge_areas)
       .where(knowledge_areas: { id: current_knowledge_area_ids })
       .group('knowledge_area_content_records.id')
       .having('COUNT(DISTINCT knowledge_areas.id) = ?', current_knowledge_area_ids.size)
-      .includes(:knowledge_areas)
+      .select('knowledge_area_content_records.id')
 
-    # Verifica se algum registro tem exatamente as mesmas áreas de conhecimento
-    matching_records.each do |record|
-      existing_knowledge_area_ids = record.knowledge_areas.map(&:id).sort
+    # Se encontrou registros com o mesmo número de áreas, verifica se são exatamente as mesmas
+    if matching_records.any?
+      # Carrega os registros completos com suas áreas de conhecimento
+      candidate_ids = matching_records.pluck(:id)
+      candidates = KnowledgeAreaContentRecord.where(id: candidate_ids).includes(:knowledge_areas)
       
-      if existing_knowledge_area_ids == current_knowledge_area_ids
-        errors.add(:knowledge_area_ids, :knowledge_area_in_use)
-        Rails.logger.error "=== Validação de unicidade falhou para teacher_id: #{content_record.teacher_id}, classroom_id: #{content_record.classroom_id}, knowledge_area_ids: #{current_knowledge_area_ids}, date: #{content_record.record_date} ==="
-        return
+      candidates.each do |record|
+        existing_knowledge_area_ids = record.knowledge_areas.map(&:id).sort
+        
+        if existing_knowledge_area_ids == current_knowledge_area_ids
+          errors.add(:knowledge_area_ids, :knowledge_area_in_use)
+          return
+        end
       end
     end
   end

--- a/app/reports/exam_record_all_steps_averages_adaptive_report.rb
+++ b/app/reports/exam_record_all_steps_averages_adaptive_report.rb
@@ -1,6 +1,6 @@
 require 'action_view'
 
-class ExamRecordAllStepsAveragesReport < BaseReport
+class ExamRecordAllStepsAveragesAdaptiveReport < BaseReport
   include ActionView::Helpers::NumberHelper
 
   STUDENT_BY_PAGE_COUNT = 40
@@ -86,16 +86,11 @@ class ExamRecordAllStepsAveragesReport < BaseReport
   def data_table
     students = {}
     step_averages = {}
-    first_semester_averages = {}
-    second_semester_averages = {}
-    first_semester_recoveries = {}
-    second_semester_recoveries = {}
-    first_semester_final_averages = {}
-    second_semester_final_averages = {}
+    step_recoveries = {}
     final_recoveries = {}
     final_averages = {}
 
-    # Dividir etapas em semestres (geralmente metade das etapas por semestre)
+    # Dividir etapas em semestres (para definir cores)
     total_steps = @steps.size
     first_semester_steps = @steps.first((total_steps.to_f / 2).ceil)
     second_semester_steps = @steps.last(total_steps - first_semester_steps.size)
@@ -112,62 +107,28 @@ class ExamRecordAllStepsAveragesReport < BaseReport
 
       # Calcular médias de cada etapa
       step_averages[student_enrollment.id] = []
+      step_recoveries[student_enrollment.id] = []
+      
       @steps.each do |step|
         average = StudentAverageCalculator.new(student).calculate(@classroom, @discipline, step)
         step_averages[student_enrollment.id] << average
+        
+        # Buscar recuperação por etapa
+        step_recovery = AvaliationRecoveryDiaryRecord
+          .joins(recovery_diary_record: :students)
+          .where(recovery_diary_records: { classroom_id: @classroom.id, discipline_id: @discipline.id })
+          .where(recovery_diary_record_students: { student_id: student_id })
+          .by_test_date_between(step.start_at, step.end_at)
+          .order('recovery_diary_records.recorded_at DESC')
+          .first
+        
+        step_recovery_score = nil
+        if step_recovery
+          recovery_student = step_recovery.recovery_diary_record.students.find_by(student_id: student_id)
+          step_recovery_score = recovery_student&.score
+        end
+        step_recoveries[student_enrollment.id] << step_recovery_score
       end
-
-      # Calcular médias parciais dos semestres
-      first_semester_avgs = step_averages[student_enrollment.id].first(first_semester_steps.size).compact
-      second_semester_avgs = step_averages[student_enrollment.id].last(second_semester_steps.size).compact
-
-      first_semester_averages[student_enrollment.id] = first_semester_avgs.any? ? (first_semester_avgs.sum.to_f / first_semester_avgs.size) : nil
-      second_semester_averages[student_enrollment.id] = second_semester_avgs.any? ? (second_semester_avgs.sum.to_f / second_semester_avgs.size) : nil
-
-      # Buscar recuperação do 1º semestre
-      first_sem_recovery = SchoolTermRecoveryDiaryRecord
-        .joins(recovery_diary_record: :students)
-        .where(recovery_diary_records: { classroom_id: @classroom.id, discipline_id: @discipline.id })
-        .where(recovery_diary_record_students: { student_id: student_id })
-        .where('recovery_diary_records.recorded_at BETWEEN ? AND ?', first_semester_steps.first.start_at, first_semester_steps.last.end_at)
-        .order('recovery_diary_records.recorded_at DESC')
-        .first
-      
-      first_sem_recovery_score = nil
-      if first_sem_recovery
-        recovery_student = first_sem_recovery.recovery_diary_record.students.find_by(student_id: student_id)
-        first_sem_recovery_score = recovery_student&.score
-      end
-      first_semester_recoveries[student_enrollment.id] = first_sem_recovery_score
-
-      # Buscar recuperação do 2º semestre
-      second_sem_recovery = SchoolTermRecoveryDiaryRecord
-        .joins(recovery_diary_record: :students)
-        .where(recovery_diary_records: { classroom_id: @classroom.id, discipline_id: @discipline.id })
-        .where(recovery_diary_record_students: { student_id: student_id })
-        .where('recovery_diary_records.recorded_at BETWEEN ? AND ?', second_semester_steps.first.start_at, second_semester_steps.last.end_at)
-        .order('recovery_diary_records.recorded_at DESC')
-        .first
-      
-      second_sem_recovery_score = nil
-      if second_sem_recovery
-        recovery_student = second_sem_recovery.recovery_diary_record.students.find_by(student_id: student_id)
-        second_sem_recovery_score = recovery_student&.score
-      end
-      second_semester_recoveries[student_enrollment.id] = second_sem_recovery_score
-
-      # Calcular médias finais dos semestres (aplicando recuperação se houver)
-      first_sem_final = first_semester_averages[student_enrollment.id]
-      if first_sem_recovery_score.present? && first_sem_recovery_score.to_f > (first_sem_final || 0).to_f
-        first_sem_final = first_sem_recovery_score.to_f
-      end
-      first_semester_final_averages[student_enrollment.id] = first_sem_final ? ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, first_semester_steps.last).round(first_sem_final) : nil
-
-      second_sem_final = second_semester_averages[student_enrollment.id]
-      if second_sem_recovery_score.present? && second_sem_recovery_score.to_f > (second_sem_final || 0).to_f
-        second_sem_final = second_sem_recovery_score.to_f
-      end
-      second_semester_final_averages[student_enrollment.id] = second_sem_final ? ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, second_semester_steps.last).round(second_sem_final) : nil
 
       # Buscar recuperação final
       final_recovery_record = FinalRecoveryDiaryRecord
@@ -184,9 +145,9 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       end
       final_recoveries[student_enrollment.id] = final_recovery_score
 
-      # Calcular média final (média das médias finais dos semestres, aplicando recuperação final se houver)
-      semester_finals = [first_semester_final_averages[student_enrollment.id], second_semester_final_averages[student_enrollment.id]].compact
-      final_average = semester_finals.any? ? (semester_finals.sum.to_f / semester_finals.size) : nil
+      # Calcular média final (média de todas as etapas, aplicando recuperação final se houver)
+      all_step_averages = step_averages[student_enrollment.id].compact
+      final_average = all_step_averages.any? ? (all_step_averages.sum.to_f / all_step_averages.size) : nil
       
       if final_recovery_score.present? && final_recovery_score.to_f > (final_average || 0).to_f
         final_average = final_recovery_score.to_f
@@ -195,71 +156,40 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       final_averages[student_enrollment.id] = final_average ? ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, @steps.last).round(final_average) : nil
     end
 
-    # Construir tabela conforme a imagem
+    # Construir tabela com recuperação por etapa
     sequential_number_header = make_cell(content: 'Nº', size: 7, font_style: :bold, background_color: 'FFFFFF', align: :center)
     student_name_header = make_cell(content: 'Nome do aluno', size: 7, font_style: :bold, background_color: 'FFFFFF', align: :center)
 
-    # Headers das etapas individuais - Branco
-    first_semester_step_headers = first_semester_steps.map do |step|
-      make_cell(content: "#{step.step_number}ª Etapa", size: 7, font_style: :bold, background_color: STEP_BG_COLOR, align: :center)
+    # Headers com recuperação por etapa (sem MP semestral)
+    step_headers = []
+    @steps.each_with_index do |step, index|
+      step_headers << make_cell(content: "#{step.step_number}ª Etapa", size: 7, font_style: :bold, background_color: STEP_BG_COLOR, align: :center)
+      rec_bg_color = index < first_semester_steps.size ? FIRST_SEMESTER_BG_COLOR : SECOND_SEMESTER_BG_COLOR
+      step_headers << make_cell(content: "Rec\n#{step.step_number}ª", size: 7, font_style: :bold, background_color: rec_bg_color, align: :center, valign: :center)
     end
-
-    # Headers das etapas individuais - Branco
-    second_semester_step_headers = second_semester_steps.map do |step|
-      make_cell(content: "#{step.step_number}ª Etapa", size: 7, font_style: :bold, background_color: STEP_BG_COLOR, align: :center)
-    end
-
-    # Headers do 1º semestre
-    mp_first_sem_header = make_cell(content: "MP\n1º Sem", size: 7, font_style: :bold, background_color: FIRST_SEMESTER_BG_COLOR, align: :center, valign: :center)
-    rec_first_sem_header = make_cell(content: "Rec.\n1º Sem", size: 7, font_style: :bold, background_color: FIRST_SEMESTER_BG_COLOR, align: :center, valign: :center)
-    final_first_sem_header = make_cell(content: "Média\n1º Sem", size: 7, font_style: :bold, background_color: SEMESTER_AVG_BG_COLOR, align: :center, valign: :center)
-
-    # Headers do 2º semestre
-    mp_second_sem_header = make_cell(content: "MP\n2º Sem", size: 7, font_style: :bold, background_color: SECOND_SEMESTER_BG_COLOR, align: :center, valign: :center)
-    rec_second_sem_header = make_cell(content: "Rec\n2º Sem", size: 7, font_style: :bold, background_color: SECOND_SEMESTER_BG_COLOR, align: :center, valign: :center)
-    final_second_sem_header = make_cell(content: "Média\n2º Sem", size: 7, font_style: :bold, background_color: SEMESTER_AVG_BG_COLOR, align: :center, valign: :center)
 
     # Headers finais
     rec_final_header = make_cell(content: "Rec\nFinal", size: 7, font_style: :bold, background_color: SEMESTER_AVG_BG_COLOR, align: :center, valign: :center)
     final_average_header = make_cell(content: "Média\nFinal", size: 7, font_style: :bold, background_color: FINAL_AVG_BG_COLOR, align: :center, valign: :center)
 
-    # Nova ordem: Nº, Nome, 1ª Etapa, 2ª Etapa, MP 1º Sem, Rec. 1º Sem, Média 1º Sem, 3ª Etapa, 4ª Etapa, MP 2º Sem, Rec 2º Sem, Média 2º Sem, Rec Final, Média Final
     headers = [sequential_number_header, student_name_header] + 
-              first_semester_step_headers +
-              [mp_first_sem_header, rec_first_sem_header, final_first_sem_header] +
-              second_semester_step_headers +
-              [mp_second_sem_header, rec_second_sem_header, final_second_sem_header] +
+              step_headers +
               [rec_final_header, final_average_header]
 
     students_data = []
     @students_enrollments.each_with_index do |student_enrollment, index|
-      # Dividir médias das etapas por semestre
-      first_semester_step_averages = step_averages[student_enrollment.id].first(first_semester_steps.size)
-      second_semester_step_averages = step_averages[student_enrollment.id].last(second_semester_steps.size)
-
-      # Nova ordem: Nº, Nome, 1ª Etapa, 2ª Etapa, MP 1º Sem, Rec. 1º Sem, Média 1º Sem, 3ª Etapa, 4ª Etapa, MP 2º Sem, Rec 2º Sem, Média 2º Sem, Rec Final, Média Final
       row = [make_cell(content: (index + 1).to_s, size: 7, align: :center),
              make_cell(content: students[student_enrollment.id][:name], size: 7, align: :left)]
 
-      # Notas das etapas do 1º semestre - Branco
-      first_semester_step_averages.each do |average|
+      # Dados com recuperação por etapa (sem MP semestral)
+      @steps.each_with_index do |step, step_index|
+        average = step_averages[student_enrollment.id][step_index]
+        recovery = step_recoveries[student_enrollment.id][step_index]
+        rec_bg_color = step_index < first_semester_steps.size ? FIRST_SEMESTER_BG_COLOR : SECOND_SEMESTER_BG_COLOR
+        
         row << make_cell(content: localize_score(average), size: 7, align: :center, background_color: STEP_BG_COLOR)
+        row << make_cell(content: localize_score(recovery), size: 7, align: :center, background_color: rec_bg_color)
       end
-
-      # Dados do 1º semestre
-      row << make_cell(content: localize_score(first_semester_averages[student_enrollment.id]), size: 7, align: :center, background_color: FIRST_SEMESTER_BG_COLOR)
-      row << make_cell(content: localize_score(first_semester_recoveries[student_enrollment.id]), size: 7, align: :center, background_color: FIRST_SEMESTER_BG_COLOR)
-      row << make_cell(content: localize_score(first_semester_final_averages[student_enrollment.id]), size: 7, align: :center, background_color: SEMESTER_AVG_BG_COLOR)
-
-      # Notas das etapas do 2º semestre - Branco
-      second_semester_step_averages.each do |average|
-        row << make_cell(content: localize_score(average), size: 7, align: :center, background_color: STEP_BG_COLOR)
-      end
-
-      # Dados do 2º semestre
-      row << make_cell(content: localize_score(second_semester_averages[student_enrollment.id]), size: 7, align: :center, background_color: SECOND_SEMESTER_BG_COLOR)
-      row << make_cell(content: localize_score(second_semester_recoveries[student_enrollment.id]), size: 7, align: :center, background_color: SECOND_SEMESTER_BG_COLOR)
-      row << make_cell(content: localize_score(second_semester_final_averages[student_enrollment.id]), size: 7, align: :center, background_color: SEMESTER_AVG_BG_COLOR)
 
       # Dados finais
       row << make_cell(content: localize_score(final_recoveries[student_enrollment.id]), size: 7, align: :center, background_color: SEMESTER_AVG_BG_COLOR)

--- a/app/reports/exam_record_all_steps_averages_adaptive_report.rb
+++ b/app/reports/exam_record_all_steps_averages_adaptive_report.rb
@@ -6,12 +6,12 @@ class ExamRecordAllStepsAveragesAdaptiveReport < BaseReport
   STUDENT_BY_PAGE_COUNT = 40
   SOCIAL_NAME_REDUCTION_FACTOR = 3
   
-  # Cores neutras para distinguir os grupos de colunas
+  # Cores neutras para distinguir os grupos de colunas (melhor contraste para legibilidade)
   STEP_BG_COLOR = 'FFFFFF'            # Branco para etapas
-  FIRST_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 1º semestre (MP e Rec)
-  SECOND_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 2º semestre (MP e Rec)
-  SEMESTER_AVG_BG_COLOR = 'E8E8E8'    # Cinza médio para Média 1º Sem, Média 2º Sem e Rec Final
-  FINAL_AVG_BG_COLOR = 'D0D0D0'       # Cinza mais escuro para Média Final
+  FIRST_SEMESTER_BG_COLOR = 'F0F0F0'  # Cinza muito claro para 1º semestre (MP e Rec)
+  SECOND_SEMESTER_BG_COLOR = 'F0F0F0'  # Cinza muito claro para 2º semestre (MP e Rec)
+  SEMESTER_AVG_BG_COLOR = 'D0D0D0'    # Cinza médio para Média 1º Sem, Média 2º Sem e Rec Final (melhor contraste)
+  FINAL_AVG_BG_COLOR = 'B0B0B0'       # Cinza mais escuro para Média Final (melhor contraste)
 
   def self.build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
     new(:portrait).build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)

--- a/app/reports/exam_record_all_steps_averages_adaptive_report.rb
+++ b/app/reports/exam_record_all_steps_averages_adaptive_report.rb
@@ -10,8 +10,8 @@ class ExamRecordAllStepsAveragesAdaptiveReport < BaseReport
   STEP_BG_COLOR = 'FFFFFF'            # Branco para etapas
   FIRST_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 1º semestre (MP e Rec)
   SECOND_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 2º semestre (MP e Rec)
-  SEMESTER_AVG_BG_COLOR = 'D3D3D3'    # Cinza levemente escuro para Média 1º Sem, Média 2º Sem e Rec Final
-  FINAL_AVG_BG_COLOR = 'B0B0B0'       # Cinza um pouco mais escuro para Média Final
+  SEMESTER_AVG_BG_COLOR = 'E8E8E8'    # Cinza médio para Média 1º Sem, Média 2º Sem e Rec Final
+  FINAL_AVG_BG_COLOR = 'D0D0D0'       # Cinza mais escuro para Média Final
 
   def self.build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
     new(:portrait).build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
@@ -28,6 +28,7 @@ class ExamRecordAllStepsAveragesAdaptiveReport < BaseReport
     @active_search = false
 
     header
+    move_down 10
     content
     footer
 
@@ -68,7 +69,8 @@ class ExamRecordAllStepsAveragesAdaptiveReport < BaseReport
                         [teacher_cell],
                         [discipline_header, discipline_cell]]
 
-    repeat(:first) do
+    # Renderizar cabeçalho apenas na primeira página usando repeat
+    repeat(lambda { |pg| pg == 1 }) do
       table(first_table_data, width: bounds.width, header: true) do
         cells.border_width = 0.25
         row(0).border_top_width = 0.25

--- a/app/reports/exam_record_all_steps_averages_report.rb
+++ b/app/reports/exam_record_all_steps_averages_report.rb
@@ -120,11 +120,25 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       end
 
       # Calcular médias parciais dos semestres
-      first_semester_avgs = step_averages[student_enrollment.id].first(first_semester_steps.size).compact
-      second_semester_avgs = step_averages[student_enrollment.id].last(second_semester_steps.size).compact
+      # Notas em branco (nil) devem ser consideradas como 0 na média
+      first_semester_values  = step_averages[student_enrollment.id].first(first_semester_steps.size)
+      second_semester_values = step_averages[student_enrollment.id].last(second_semester_steps.size)
 
-      first_semester_averages[student_enrollment.id] = first_semester_avgs.any? ? (first_semester_avgs.sum.to_f / first_semester_avgs.size) : nil
-      second_semester_averages[student_enrollment.id] = second_semester_avgs.any? ? (second_semester_avgs.sum.to_f / second_semester_avgs.size) : nil
+      if first_semester_values.any?
+        first_semester_sum   = first_semester_values.map { |v| v.to_f }.sum
+        first_semester_count = first_semester_values.size
+        first_semester_averages[student_enrollment.id] = first_semester_sum / first_semester_count
+      else
+        first_semester_averages[student_enrollment.id] = nil
+      end
+
+      if second_semester_values.any?
+        second_semester_sum   = second_semester_values.map { |v| v.to_f }.sum
+        second_semester_count = second_semester_values.size
+        second_semester_averages[student_enrollment.id] = second_semester_sum / second_semester_count
+      else
+        second_semester_averages[student_enrollment.id] = nil
+      end
 
       # Buscar recuperação do 1º semestre
       first_sem_recovery = SchoolTermRecoveryDiaryRecord

--- a/app/reports/exam_record_all_steps_averages_report.rb
+++ b/app/reports/exam_record_all_steps_averages_report.rb
@@ -6,12 +6,12 @@ class ExamRecordAllStepsAveragesReport < BaseReport
   STUDENT_BY_PAGE_COUNT = 40
   SOCIAL_NAME_REDUCTION_FACTOR = 3
   
-  # Cores neutras para distinguir os grupos de colunas
+  # Cores neutras para distinguir os grupos de colunas (melhor contraste para legibilidade)
   STEP_BG_COLOR = 'FFFFFF'            # Branco para etapas
-  FIRST_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 1º semestre (MP e Rec)
-  SECOND_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 2º semestre (MP e Rec)
-  SEMESTER_AVG_BG_COLOR = 'E8E8E8'    # Cinza médio para Média 1º Sem, Média 2º Sem e Rec Final
-  FINAL_AVG_BG_COLOR = 'D0D0D0'       # Cinza mais escuro para Média Final
+  FIRST_SEMESTER_BG_COLOR = 'F0F0F0'  # Cinza muito claro para 1º semestre (MP e Rec)
+  SECOND_SEMESTER_BG_COLOR = 'F0F0F0'  # Cinza muito claro para 2º semestre (MP e Rec)
+  SEMESTER_AVG_BG_COLOR = 'D0D0D0'    # Cinza médio para Média 1º Sem, Média 2º Sem e Rec Final (melhor contraste)
+  FINAL_AVG_BG_COLOR = 'B0B0B0'       # Cinza mais escuro para Média Final (melhor contraste)
 
   def self.build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
     new(:portrait).build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
@@ -124,10 +124,15 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       first_semester_values  = step_averages[student_enrollment.id].first(first_semester_steps.size)
       second_semester_values = step_averages[student_enrollment.id].last(second_semester_steps.size)
 
+      # Armazenar valores não arredondados para cálculos posteriores
+      first_semester_avg_raw = nil
+      second_semester_avg_raw = nil
+
       if first_semester_values.any?
         first_semester_sum   = first_semester_values.map { |v| v.to_f }.sum
         first_semester_count = first_semester_values.size
-        first_semester_averages[student_enrollment.id] = first_semester_sum / first_semester_count
+        first_semester_avg_raw = first_semester_sum / first_semester_count
+        first_semester_averages[student_enrollment.id] = ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, first_semester_steps.last).round(first_semester_avg_raw)
       else
         first_semester_averages[student_enrollment.id] = nil
       end
@@ -135,7 +140,8 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       if second_semester_values.any?
         second_semester_sum   = second_semester_values.map { |v| v.to_f }.sum
         second_semester_count = second_semester_values.size
-        second_semester_averages[student_enrollment.id] = second_semester_sum / second_semester_count
+        second_semester_avg_raw = second_semester_sum / second_semester_count
+        second_semester_averages[student_enrollment.id] = ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, second_semester_steps.last).round(second_semester_avg_raw)
       else
         second_semester_averages[student_enrollment.id] = nil
       end
@@ -173,13 +179,14 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       second_semester_recoveries[student_enrollment.id] = second_sem_recovery_score
 
       # Calcular médias finais dos semestres (aplicando recuperação se houver)
-      first_sem_final = first_semester_averages[student_enrollment.id]
+      # Usar valor não arredondado para comparação e cálculo
+      first_sem_final = first_semester_avg_raw
       if first_sem_recovery_score.present? && first_sem_recovery_score.to_f > (first_sem_final || 0).to_f
         first_sem_final = first_sem_recovery_score.to_f
       end
       first_semester_final_averages[student_enrollment.id] = first_sem_final ? ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, first_semester_steps.last).round(first_sem_final) : nil
 
-      second_sem_final = second_semester_averages[student_enrollment.id]
+      second_sem_final = second_semester_avg_raw
       if second_sem_recovery_score.present? && second_sem_recovery_score.to_f > (second_sem_final || 0).to_f
         second_sem_final = second_sem_recovery_score.to_f
       end
@@ -201,8 +208,10 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       final_recoveries[student_enrollment.id] = final_recovery_score
 
       # Calcular média final (média das médias finais dos semestres, aplicando recuperação final se houver)
-      semester_finals = [first_semester_final_averages[student_enrollment.id], second_semester_final_averages[student_enrollment.id]].compact
-      final_average = semester_finals.any? ? (semester_finals.sum.to_f / semester_finals.size) : nil
+      # Considera MP1 e MP2 como zero quando vazios
+      mp1 = first_semester_final_averages[student_enrollment.id] || 0
+      mp2 = second_semester_final_averages[student_enrollment.id] || 0
+      final_average = (mp1.to_f + mp2.to_f) / 2.0
       
       if final_recovery_score.present? && final_recovery_score.to_f > (final_average || 0).to_f
         final_average = final_recovery_score.to_f

--- a/app/reports/exam_record_all_steps_averages_report.rb
+++ b/app/reports/exam_record_all_steps_averages_report.rb
@@ -1,0 +1,286 @@
+require 'action_view'
+
+class ExamRecordAllStepsAveragesReport < BaseReport
+  include ActionView::Helpers::NumberHelper
+
+  STUDENT_BY_PAGE_COUNT = 40
+  SOCIAL_NAME_REDUCTION_FACTOR = 3
+  
+  # Cores neutras para distinguir os grupos de colunas
+  FIRST_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 1º semestre
+  SECOND_SEMESTER_BG_COLOR = 'E8E8E8'  # Cinza médio claro para 2º semestre
+  FINAL_BG_COLOR = 'DCDCDC'            # Cinza claro médio para dados finais
+
+  def self.build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
+    new(:portrait).build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
+  end
+
+  def build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
+    @entity_configuration = entity_configuration
+    @teacher = teacher
+    @year = year
+    @classroom = classroom
+    @discipline = discipline
+    @steps = steps
+    @students_enrollments = students_enrollments
+    @active_search = false
+
+    header
+    content
+    footer
+
+    self
+  end
+
+  protected
+
+  attr_accessor :any_student_with_dependence
+
+  private
+
+  def header
+    exam_header = make_cell(content: 'Registro de avaliações - Médias por Etapa', size: 12, font_style: :bold, background_color: 'DEDEDE', height: 20, padding: [2, 2, 4, 4], align: :center, colspan: 5)
+    begin
+      logo_cell = make_cell(image: open(@entity_configuration.logo.url), fit: [50, 50], width: 70, rowspan: 4, position: :center, vposition: :center)
+    rescue
+      logo_cell = make_cell(content: '', width: 70, rowspan: 4)
+    end
+
+    entity_name = @entity_configuration ? @entity_configuration.entity_name : ''
+    organ_name = @entity_configuration ? @entity_configuration.organ_name : ''
+
+    entity_organ_and_unity_cell = make_cell(content: "#{entity_name}\n#{organ_name}\n#{@classroom.unity.name}", size: 10, leading: 1.5, align: :center, valign: :center, rowspan: 4, width: 300, padding: [4, 2, 8, 2])
+    classroom_header = make_cell(content: 'Turma', size: 8, font_style: :bold, colspan: 2, borders: [:top, :left, :right], padding: [2, 2, 4, 4], height: 2)
+    year_header = make_cell(content: 'Ano letivo', size: 8, font_style: :bold, borders: [:top, :left, :right], padding: [2, 2, 4, 4], height: 2)
+    teacher_header = make_cell(content: 'Professor(a)', size: 8, font_style: :bold, colspan: 3, borders: [:top, :left, :right], padding: [2, 2, 4, 4])
+    classroom_cell = make_cell(content: @classroom.description, size: 10, colspan: 2, borders: [:bottom, :left, :right], padding: [0, 2, 4, 4], height: 4)
+    year_cell = make_cell(content: @year.to_s, size: 10, borders: [:bottom, :left, :right], padding: [0, 2, 4, 4], height: 4)
+    teacher_cell = make_cell(content: @teacher.name, size: 10, colspan: 3, borders: [:bottom, :left, :right], padding: [0, 2, 4, 4])
+    discipline_header = make_cell(content: 'Disciplina', size: 8, font_style: :bold, colspan: 1, rowspan: 1, borders: [:top, :bottom, :left], padding: [2, 2, 4, 4])
+    discipline_cell = make_cell(content: (@discipline ? @discipline.description : 'Geral'), size: 10, colspan: 4, borders: [:top, :bottom, :right], padding: [0, 2, 4, 4])
+
+    first_table_data = [[exam_header],
+                        [logo_cell, entity_organ_and_unity_cell, classroom_header, year_header],
+                        [classroom_cell, year_cell],
+                        [teacher_header],
+                        [teacher_cell],
+                        [discipline_header, discipline_cell]]
+
+    page_header do
+      table(first_table_data, width: bounds.width, header: true) do
+        cells.border_width = 0.25
+        row(0).border_top_width = 0.25
+        row(-1).border_bottom_width = 0.25
+        column(0).border_left_width = 0.25
+        column(-1).border_right_width = 0.25
+      end
+    end
+  end
+
+  def content
+    data_table
+  end
+
+  def data_table
+    students = {}
+    step_averages = {}
+    first_semester_averages = {}
+    second_semester_averages = {}
+    first_semester_recoveries = {}
+    second_semester_recoveries = {}
+    first_semester_final_averages = {}
+    second_semester_final_averages = {}
+    final_recoveries = {}
+    final_averages = {}
+
+    # Dividir etapas em semestres (geralmente metade das etapas por semestre)
+    total_steps = @steps.size
+    first_semester_steps = @steps.first((total_steps.to_f / 2).ceil)
+    second_semester_steps = @steps.last(total_steps - first_semester_steps.size)
+
+    @students_enrollments.each do |student_enrollment|
+      student_id = student_enrollment.student_id
+      student = student_enrollment.student
+
+      students[student_enrollment.id] = {
+        name: student.to_s,
+        social_name: student.social_name,
+        student_id: student.id
+      }
+
+      # Calcular médias de cada etapa
+      step_averages[student_enrollment.id] = []
+      @steps.each do |step|
+        average = StudentAverageCalculator.new(student).calculate(@classroom, @discipline, step)
+        step_averages[student_enrollment.id] << average
+      end
+
+      # Calcular médias parciais dos semestres
+      first_semester_avgs = step_averages[student_enrollment.id].first(first_semester_steps.size).compact
+      second_semester_avgs = step_averages[student_enrollment.id].last(second_semester_steps.size).compact
+
+      first_semester_averages[student_enrollment.id] = first_semester_avgs.any? ? (first_semester_avgs.sum.to_f / first_semester_avgs.size) : nil
+      second_semester_averages[student_enrollment.id] = second_semester_avgs.any? ? (second_semester_avgs.sum.to_f / second_semester_avgs.size) : nil
+
+      # Buscar recuperação do 1º semestre
+      first_sem_recovery = SchoolTermRecoveryDiaryRecord
+        .joins(recovery_diary_record: :students)
+        .where(recovery_diary_records: { classroom_id: @classroom.id, discipline_id: @discipline.id })
+        .where(recovery_diary_record_students: { student_id: student_id })
+        .where('recovery_diary_records.recorded_at BETWEEN ? AND ?', first_semester_steps.first.start_at, first_semester_steps.last.end_at)
+        .order('recovery_diary_records.recorded_at DESC')
+        .first
+      
+      first_sem_recovery_score = nil
+      if first_sem_recovery
+        recovery_student = first_sem_recovery.recovery_diary_record.students.find_by(student_id: student_id)
+        first_sem_recovery_score = recovery_student&.score
+      end
+      first_semester_recoveries[student_enrollment.id] = first_sem_recovery_score
+
+      # Buscar recuperação do 2º semestre
+      second_sem_recovery = SchoolTermRecoveryDiaryRecord
+        .joins(recovery_diary_record: :students)
+        .where(recovery_diary_records: { classroom_id: @classroom.id, discipline_id: @discipline.id })
+        .where(recovery_diary_record_students: { student_id: student_id })
+        .where('recovery_diary_records.recorded_at BETWEEN ? AND ?', second_semester_steps.first.start_at, second_semester_steps.last.end_at)
+        .order('recovery_diary_records.recorded_at DESC')
+        .first
+      
+      second_sem_recovery_score = nil
+      if second_sem_recovery
+        recovery_student = second_sem_recovery.recovery_diary_record.students.find_by(student_id: student_id)
+        second_sem_recovery_score = recovery_student&.score
+      end
+      second_semester_recoveries[student_enrollment.id] = second_sem_recovery_score
+
+      # Calcular médias finais dos semestres (aplicando recuperação se houver)
+      first_sem_final = first_semester_averages[student_enrollment.id]
+      if first_sem_recovery_score.present? && first_sem_recovery_score.to_f > (first_sem_final || 0).to_f
+        first_sem_final = first_sem_recovery_score.to_f
+      end
+      first_semester_final_averages[student_enrollment.id] = first_sem_final ? ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, first_semester_steps.last).round(first_sem_final) : nil
+
+      second_sem_final = second_semester_averages[student_enrollment.id]
+      if second_sem_recovery_score.present? && second_sem_recovery_score.to_f > (second_sem_final || 0).to_f
+        second_sem_final = second_sem_recovery_score.to_f
+      end
+      second_semester_final_averages[student_enrollment.id] = second_sem_final ? ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, second_semester_steps.last).round(second_sem_final) : nil
+
+      # Buscar recuperação final
+      final_recovery_record = FinalRecoveryDiaryRecord
+        .joins(recovery_diary_record: :students)
+        .where(recovery_diary_records: { classroom_id: @classroom.id, discipline_id: @discipline.id })
+        .where(recovery_diary_record_students: { student_id: student_id })
+        .where(school_calendar_id: @classroom.unity.school_calendars.by_year(@year).first&.id)
+        .first
+      
+      final_recovery_score = nil
+      if final_recovery_record
+        recovery_student = final_recovery_record.recovery_diary_record.students.find_by(student_id: student_id)
+        final_recovery_score = recovery_student&.score
+      end
+      final_recoveries[student_enrollment.id] = final_recovery_score
+
+      # Calcular média final (média das médias finais dos semestres, aplicando recuperação final se houver)
+      semester_finals = [first_semester_final_averages[student_enrollment.id], second_semester_final_averages[student_enrollment.id]].compact
+      final_average = semester_finals.any? ? (semester_finals.sum.to_f / semester_finals.size) : nil
+      
+      if final_recovery_score.present? && final_recovery_score.to_f > (final_average || 0).to_f
+        final_average = final_recovery_score.to_f
+      end
+      
+      final_averages[student_enrollment.id] = final_average ? ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, @steps.last).round(final_average) : nil
+    end
+
+    # Construir tabela conforme a imagem
+    sequential_number_header = make_cell(content: 'Nº', size: 7, font_style: :bold, background_color: 'FFFFFF', align: :center)
+    student_name_header = make_cell(content: 'Nome do aluno', size: 7, font_style: :bold, background_color: 'FFFFFF', align: :center)
+
+    # Headers das etapas individuais - Cor 1: 1º semestre (cinza claro)
+    first_semester_step_headers = first_semester_steps.map do |step|
+      make_cell(content: "#{step.step_number}ª Etapa", size: 7, font_style: :bold, background_color: FIRST_SEMESTER_BG_COLOR, align: :center)
+    end
+
+    # Headers das etapas individuais - Cor 2: 2º semestre (bege claro)
+    second_semester_step_headers = second_semester_steps.map do |step|
+      make_cell(content: "#{step.step_number}ª Etapa", size: 7, font_style: :bold, background_color: SECOND_SEMESTER_BG_COLOR, align: :center)
+    end
+
+    # Headers do 1º semestre - Cor 1
+    mp_first_sem_header = make_cell(content: "MP\n1º Sem", size: 7, font_style: :bold, background_color: FIRST_SEMESTER_BG_COLOR, align: :center, valign: :center)
+    rec_first_sem_header = make_cell(content: "Rec.\n1º Sem", size: 7, font_style: :bold, background_color: FIRST_SEMESTER_BG_COLOR, align: :center, valign: :center)
+    final_first_sem_header = make_cell(content: "Média\n1º Sem", size: 7, font_style: :bold, background_color: FIRST_SEMESTER_BG_COLOR, align: :center, valign: :center)
+
+    # Headers do 2º semestre - Cor 2
+    mp_second_sem_header = make_cell(content: "MP\n2º Sem", size: 7, font_style: :bold, background_color: SECOND_SEMESTER_BG_COLOR, align: :center, valign: :center)
+    rec_second_sem_header = make_cell(content: "Rec\n2º Sem", size: 7, font_style: :bold, background_color: SECOND_SEMESTER_BG_COLOR, align: :center, valign: :center)
+    final_second_sem_header = make_cell(content: "Média\n2º Sem", size: 7, font_style: :bold, background_color: SECOND_SEMESTER_BG_COLOR, align: :center, valign: :center)
+
+    # Headers finais - Cor 3
+    rec_final_header = make_cell(content: "Rec\nFinal", size: 7, font_style: :bold, background_color: FINAL_BG_COLOR, align: :center, valign: :center)
+    final_average_header = make_cell(content: "Média\nFinal", size: 7, font_style: :bold, background_color: FINAL_BG_COLOR, align: :center, valign: :center)
+
+    # Nova ordem: Nº, Nome, 1ª Etapa, 2ª Etapa, MP 1º Sem, Rec. 1º Sem, Média 1º Sem, 3ª Etapa, 4ª Etapa, MP 2º Sem, Rec 2º Sem, Média 2º Sem, Rec Final, Média Final
+    headers = [sequential_number_header, student_name_header] + 
+              first_semester_step_headers +
+              [mp_first_sem_header, rec_first_sem_header, final_first_sem_header] +
+              second_semester_step_headers +
+              [mp_second_sem_header, rec_second_sem_header, final_second_sem_header] +
+              [rec_final_header, final_average_header]
+
+    students_data = []
+    @students_enrollments.each_with_index do |student_enrollment, index|
+      # Dividir médias das etapas por semestre
+      first_semester_step_averages = step_averages[student_enrollment.id].first(first_semester_steps.size)
+      second_semester_step_averages = step_averages[student_enrollment.id].last(second_semester_steps.size)
+
+      # Nova ordem: Nº, Nome, 1ª Etapa, 2ª Etapa, MP 1º Sem, Rec. 1º Sem, Média 1º Sem, 3ª Etapa, 4ª Etapa, MP 2º Sem, Rec 2º Sem, Média 2º Sem, Rec Final, Média Final
+      row = [make_cell(content: (index + 1).to_s, size: 7, align: :center),
+             make_cell(content: students[student_enrollment.id][:name], size: 7, align: :left)]
+
+      # Notas das etapas do 1º semestre - Cor 1
+      first_semester_step_averages.each do |average|
+        row << make_cell(content: localize_score(average), size: 7, align: :center, background_color: FIRST_SEMESTER_BG_COLOR)
+      end
+
+      # Dados do 1º semestre - Cor 1
+      row << make_cell(content: localize_score(first_semester_averages[student_enrollment.id]), size: 7, align: :center, background_color: FIRST_SEMESTER_BG_COLOR)
+      row << make_cell(content: localize_score(first_semester_recoveries[student_enrollment.id]), size: 7, align: :center, background_color: FIRST_SEMESTER_BG_COLOR)
+      row << make_cell(content: localize_score(first_semester_final_averages[student_enrollment.id]), size: 7, align: :center, background_color: FIRST_SEMESTER_BG_COLOR)
+
+      # Notas das etapas do 2º semestre - Cor 2
+      second_semester_step_averages.each do |average|
+        row << make_cell(content: localize_score(average), size: 7, align: :center, background_color: SECOND_SEMESTER_BG_COLOR)
+      end
+
+      # Dados do 2º semestre - Cor 2
+      row << make_cell(content: localize_score(second_semester_averages[student_enrollment.id]), size: 7, align: :center, background_color: SECOND_SEMESTER_BG_COLOR)
+      row << make_cell(content: localize_score(second_semester_recoveries[student_enrollment.id]), size: 7, align: :center, background_color: SECOND_SEMESTER_BG_COLOR)
+      row << make_cell(content: localize_score(second_semester_final_averages[student_enrollment.id]), size: 7, align: :center, background_color: SECOND_SEMESTER_BG_COLOR)
+
+      # Dados finais - Cor 3
+      row << make_cell(content: localize_score(final_recoveries[student_enrollment.id]), size: 7, align: :center, background_color: FINAL_BG_COLOR)
+      row << make_cell(content: localize_score(final_averages[student_enrollment.id]), size: 7, align: :center, font_style: :bold, background_color: FINAL_BG_COLOR)
+
+      students_data << row
+    end
+
+    table_data = [headers] + students_data
+
+    table(table_data, width: bounds.width, header: true) do
+      cells.border_width = 0.25
+      # Não aplicar background_color globalmente na linha 0 para preservar as cores individuais dos cabeçalhos
+      row(0).font_style = :bold
+    end
+  end
+
+
+  def localize_score(score)
+    return '' if score.blank?
+    return score if score == 'D' || score == 'N'
+
+    number_with_precision(score, precision: 1, separator: ',', delimiter: '.')
+  end
+end
+

--- a/app/reports/exam_record_all_steps_averages_report.rb
+++ b/app/reports/exam_record_all_steps_averages_report.rb
@@ -10,8 +10,8 @@ class ExamRecordAllStepsAveragesReport < BaseReport
   STEP_BG_COLOR = 'FFFFFF'            # Branco para etapas
   FIRST_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 1º semestre (MP e Rec)
   SECOND_SEMESTER_BG_COLOR = 'F5F5F5'  # Cinza claro para 2º semestre (MP e Rec)
-  SEMESTER_AVG_BG_COLOR = 'D3D3D3'    # Cinza levemente escuro para Média 1º Sem, Média 2º Sem e Rec Final
-  FINAL_AVG_BG_COLOR = 'B0B0B0'       # Cinza um pouco mais escuro para Média Final
+  SEMESTER_AVG_BG_COLOR = 'E8E8E8'    # Cinza médio para Média 1º Sem, Média 2º Sem e Rec Final
+  FINAL_AVG_BG_COLOR = 'D0D0D0'       # Cinza mais escuro para Média Final
 
   def self.build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
     new(:portrait).build(entity_configuration, teacher, year, classroom, discipline, steps, students_enrollments)
@@ -28,6 +28,7 @@ class ExamRecordAllStepsAveragesReport < BaseReport
     @active_search = false
 
     header
+    move_down 10
     content
     footer
 
@@ -68,7 +69,8 @@ class ExamRecordAllStepsAveragesReport < BaseReport
                         [teacher_cell],
                         [discipline_header, discipline_cell]]
 
-    repeat(:first) do
+    # Renderizar cabeçalho apenas na primeira página usando repeat
+    repeat(lambda { |pg| pg == 1 }) do
       table(first_table_data, width: bounds.width, header: true) do
         cells.border_width = 0.25
         row(0).border_top_width = 0.25

--- a/app/services/lesson_boards_service.rb
+++ b/app/services/lesson_boards_service.rb
@@ -27,8 +27,8 @@ class LessonBoardsService
 
   def linked_teacher(teacher_discipline_classroom_id, lesson_number, weekday, classroom, period)
     teacher_discipline_classroom = TeacherDisciplineClassroom.includes(:teacher, classroom: :unity)
-                                                             .find(teacher_discipline_classroom_id)
                                                              .by_period(period)
+                                                             .find_by(id: teacher_discipline_classroom_id)
     return false if teacher_discipline_classroom.blank?
     teacher_id = teacher_discipline_classroom.teacher.id
     year = teacher_discipline_classroom.classroom.year

--- a/app/services/navigation/breadcrumbs_render.rb
+++ b/app/services/navigation/breadcrumbs_render.rb
@@ -21,7 +21,7 @@ module Navigation
             html << content_tag(:i, "", :class => "fa #{params[:icon]} fa-fw")
           end
 
-          html << Translator.t("navigation.#{params[:type]}")
+          html << menu_text(params[:type])
 
           raw html.join(" ")
         end

--- a/app/services/navigation/menu_render.rb
+++ b/app/services/navigation/menu_render.rb
@@ -32,7 +32,7 @@ module Navigation
 
           li << link_to(menu_path) do
             link = []
-            link_content = Translator.t("navigation.#{menu[:type]}")
+            link_content = menu_text(menu[:type])
 
             link << content_tag(:i, '', class: "fa fa-lg fa-fw #{menu[:icon]}") if menu[:icon]
 
@@ -61,5 +61,6 @@ module Navigation
         can_show?(node[:type])
       end
     end
+
   end
 end

--- a/app/services/navigation/render/base.rb
+++ b/app/services/navigation/render/base.rb
@@ -53,6 +53,22 @@ module Navigation
           result
         end
       end
+
+      def menu_text(menu_type)
+        if menu_type == 'school_term_recovery_diary_records'
+          semestral_recovery = Rails.application.secrets.try(:semestral_recovery) || 
+                              Rails.application.secrets.try(:SEMESTRAL_RECOVERY) || 
+                              false
+          
+          if semestral_recovery
+            'Recuperação Semestral'
+          else
+            Translator.t("navigation.#{menu_type}")
+          end
+        else
+          Translator.t("navigation.#{menu_type}")
+        end
+      end
     end
   end
 end

--- a/app/services/navigation/shortcut_render.rb
+++ b/app/services/navigation/shortcut_render.rb
@@ -12,7 +12,7 @@ module Navigation
       content_tag :div, class: "col-sm-4 col-md-2 col-lg-2 col-xs-6 text-center shortcut" do
         link_to(path_method(menu[:path])) do
           text = content_tag(:i, '', class: "shortcut-icon fa fa-lg fa-fw #{menu[:icon]}")
-          text + content_tag(:span, Translator.t("navigation.#{menu[:type]}"), class: '')
+          text + content_tag(:span, menu_text(menu[:type]), class: '')
         end
       end
     end

--- a/app/services/navigation/title_render.rb
+++ b/app/services/navigation/title_render.rb
@@ -17,7 +17,7 @@ module Navigation
     end
 
     def render_title(params)
-      Translator.t("navigation.#{params[:type]}")
+      menu_text(params[:type])
     end
   end
 end

--- a/app/services/report_generator.rb
+++ b/app/services/report_generator.rb
@@ -2,11 +2,25 @@
 
 class ReportGenerator
   def self.call(html, driver: :chrome)
-    RestClient.post(Rails.application.secrets.report_html_url, {
+    report_html_url = Rails.application.secrets.report_html_url
+    report_html_secret_key = Rails.application.secrets.report_html_secret_key || 
+                             Rails.application.secrets.resport_html_secret_key # Fallback para typo antigo
+    
+    raise ArgumentError, "report_html_url não configurado em secrets.yml" if report_html_url.blank?
+    raise ArgumentError, "report_html_secret_key não configurado em secrets.yml" if report_html_secret_key.blank?
+    
+    RestClient.post(report_html_url, {
       html: html,
       driver: driver
     }, {
-      Authorization: "Bearer #{Rails.application.secrets.resport_html_secret_key}"
+      Authorization: "Bearer #{report_html_secret_key}"
     })
+  rescue RestClient::ExceptionWithResponse => e
+    Rails.logger.error "Erro ao gerar relatório: #{e.message}"
+    Rails.logger.error "Response: #{e.response}" if e.response
+    raise
+  rescue StandardError => e
+    Rails.logger.error "Erro inesperado ao gerar relatório: #{e.message}"
+    raise
   end
 end

--- a/app/views/conceptual_exams/_resources.html.erb
+++ b/app/views/conceptual_exams/_resources.html.erb
@@ -9,7 +9,7 @@
         <td><%= conceptual_exam.classroom.unity %></td>
         <td><%= conceptual_exam.classroom %></td>
         <td><span class="multiline"> <%= conceptual_exam.student %> </span></td>
-        <td><%= conceptual_exam.step %></td>
+        <td><%= @only_one_conceptual_avaliation ? 'Anual' : conceptual_exam.step %></td>
         <td>
           <% conceptual_exam.teacher_id = current_teacher_id %>
           <span class='<%= conceptual_exam_label(conceptual_exam.status) %>'>

--- a/app/views/exam_record_report/form.html.erb
+++ b/app/views/exam_record_report/form.html.erb
@@ -31,6 +31,16 @@
 
       <div class="row">
         <div class="col col-sm-4">
+          <%= f.input :report_type, as: :select, 
+                collection: [
+                  ['Avaliações da etapa', 'step_evaluations'],
+                  ['Médias de todas as etapas', 'all_steps_averages']
+                ],
+                selected: @exam_record_report_form.report_type || 'step_evaluations',
+                input_html: { id: 'report_type_select', class: 'form-control' },
+                label: 'Tipo de Relatório' %>
+        </div>
+        <div class="col col-sm-4" id="step_selection">
           <% if @school_calendar_classroom_steps.any? %>
             <%= f.input :school_calendar_classroom_step_id, as: :select2, elements: @school_calendar_classroom_steps,
                   input_html: { value: @exam_record_report_form.school_calendar_classroom_step_id }, required: true %>

--- a/app/views/exam_record_report/form.html.erb
+++ b/app/views/exam_record_report/form.html.erb
@@ -31,16 +31,23 @@
 
       <div class="row">
         <div class="col col-sm-4">
-          <%= f.input :report_type, as: :select, 
-                collection: [
-                  ['Avaliações da etapa', 'step_evaluations'],
-                  ['Médias de todas as etapas', 'all_steps_averages']
-                ],
-                selected: @exam_record_report_form.report_type || 'step_evaluations',
-                input_html: { id: 'report_type_select', class: 'form-control' },
-                label: 'Tipo de Relatório' %>
+          <label class="label">Tipo de Relatório</label>
+          <div>
+            <label class="radio" style="display: block; margin-bottom: 10px;">
+              <%= radio_button_tag 'exam_record_report_form[report_type]', 'step_evaluations', 
+                  @exam_record_report_form.report_type == 'step_evaluations',
+                  id: 'report_type_step_evaluations', class: 'report_type_radio' %>
+              <i></i>Avaliações da etapa
+            </label>
+            <label class="radio" style="display: block;">
+              <%= radio_button_tag 'exam_record_report_form[report_type]', 'all_steps_averages', 
+                  (@exam_record_report_form.report_type || 'all_steps_averages') == 'all_steps_averages',
+                  id: 'report_type_all_steps_averages', class: 'report_type_radio' %>
+              <i></i>Médias de todas as etapas
+            </label>
+          </div>
         </div>
-        <div class="col col-sm-4" id="step_selection">
+        <div class="col col-sm-4" id="step_selection" style="<%= 'display: none;' if (@exam_record_report_form.report_type || 'all_steps_averages') == 'all_steps_averages' %>">
           <% if @school_calendar_classroom_steps.any? %>
             <%= f.input :school_calendar_classroom_step_id, as: :select2, elements: @school_calendar_classroom_steps,
                   input_html: { value: @exam_record_report_form.school_calendar_classroom_step_id }, required: true %>

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -220,7 +220,7 @@ navigation:
             path: "absence_justification_report_path"
         - menu:
             type: "teacher_report_cards"
-            path: "teacher_report_cards_path"
+            path: "exam_record_report_path"
         - menu:
             type: "partial_score_record_report"
             path: "partial_score_record_report_path"

--- a/script/start
+++ b/script/start
@@ -11,6 +11,7 @@ if ! test -f ".setup"; then
     REDIS_URL: redis://redis:6379/0
     shortcuts_enabled: true
     only_one_conceptual_avaliation: false
+    show_objectives: true
     " > config/secrets.yml
 
   cp config/database.sample.yml config/database.yml

--- a/script/start
+++ b/script/start
@@ -12,6 +12,7 @@ if ! test -f ".setup"; then
     shortcuts_enabled: true
     only_one_conceptual_avaliation: false
     show_objectives: true
+    SEMESTRAL_RECOVERY: true
     " > config/secrets.yml
 
   cp config/database.sample.yml config/database.yml


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new “Médias de todas as etapas” exam report with UI toggle, backend builders (including semester-aware variant), improved report generation/error handling, dynamic navigation labels, and safer validations.
> 
> - **Reports**
>   - **Exam Record Report**: Adds `report_type` (radio) with default `all_steps_averages`; hides step selection accordingly; permits param and routes to new builder; adds `ExamRecordAllStepsAveragesReport` and `ExamRecordAllStepsAveragesAdaptiveReport`; updates form validations to skip step when averaging all steps.
>   - **Report generator**: Reads `report_html_url` and `report_html_secret_key` from secrets (fallback supported), validates presence, fixes Authorization header, and adds robust error logging.
>   - **Attendance by Students**: Adds generic error rescue to show flash and render form.
> - **Navigation**
>   - Centralizes `menu_text` and makes `school_term_recovery_diary_records` label depend on secrets; replaces direct Translator calls in breadcrumb/menu/title/shortcut renders; updates `config/navigation.yml` to point `teacher_report_cards` to `exam_record_report_path`.
> - **Conceptual Exams**
>   - Exposes `@only_one_conceptual_avaliation` in index; view shows step as "Anual" when enabled.
> - **Model**
>   - Refactors `KnowledgeAreaContentRecord` uniqueness check with safer subquery and exact-area match.
> - **Service**
>   - `LessonBoardsService#linked_teacher`: uses `find_by` after scopes to avoid exceptions.
> - **Frontend**
>   - JS: toggles step field visibility/required state based on selected report type and initializes default selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57960cefaafd4d3a58600bc5768b7e3fe8a4bb3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->