### PR TITLE
Feature/pendencias professor

### DIFF
--- a/app/assets/javascripts/views/dashboard/teacher_pending_records.js
+++ b/app/assets/javascripts/views/dashboard/teacher_pending_records.js
@@ -213,12 +213,18 @@ $(function(){
         $target.html('<div class="loading-dates"><i class="fa fa-spinner fa-spin"></i> Carregando datas...</div>').slideDown();
         
         // Buscar datas via AJAX
+        // Usar knowledge_area_id se disponível (para turmas infantis), senão usar discipline_id
+        var idParam = record.knowledge_area_id ? 
+          { knowledge_area_id: record.knowledge_area_id } : 
+          { discipline_id: record.discipline_id };
+        
         $.ajax({
-          url: Routes.dates_dashboard_teacher_pending_records_pt_br_path({
-            format: 'json',
-            step_id: stepData.step_id,
-            discipline_id: record.discipline_id
-          }),
+          url: Routes.dates_dashboard_teacher_pending_records_pt_br_path(
+            Object.assign({
+              format: 'json',
+              step_id: stepData.step_id
+            }, idParam)
+          ),
           success: function(data) {
             var dates = isFrequency ? data.pending_frequency_dates : data.pending_content_dates;
             var label = isFrequency ? 'Datas pendentes de frequência' : 'Datas pendentes de conteúdo';

--- a/app/assets/javascripts/views/dashboard/teacher_pending_records.js
+++ b/app/assets/javascripts/views/dashboard/teacher_pending_records.js
@@ -20,6 +20,16 @@ $(function(){
 
   function handleFetchStepsSuccess(data) {
     steps = data.steps || [];
+    var hasLessonsBoard = data.has_lessons_board !== false; // Default true se não vier no JSON
+    
+    // Verificar se a turma tem quadro de aulas
+    if(!hasLessonsBoard) {
+      $container.html('<div class="alert alert-warning" style="margin-top: 20px;">' +
+        '<i class="fa fa-exclamation-triangle"></i> ' +
+        'Solicite à coordenação que cadastre o quadro de aulas da turma. Após isso você conseguirá visualizar as datas pendentes de frequência e conteúdo.' +
+        '</div>');
+      return;
+    }
     
     if(steps.length === 0){
       $container.html('<div class="alert alert-info">Nenhuma etapa encontrada.</div>');
@@ -105,49 +115,66 @@ $(function(){
     }
 
     var stepHtml = '<div class="panel panel-default" style="margin-top: 20px;">' +
-      '<div class="panel-heading">' +
-        '<h4 class="panel-title">' + stepData.step_name + 
-        ' <small>(' + stepData.start_at + ' a ' + stepData.end_at + ')</small></h4>' +
-      '</div>' +
       '<div class="panel-body">' +
         '<div class="table-responsive">' +
           '<table class="table table-bordered table-only-inner-bordered table-striped table-hover" style="font-size: 14px;">' +
             '<thead>' +
               '<tr>' +
                 '<th>Disciplina</th>' +
-                '<th style="width: 120px; text-align: center;">Pend. Frequência</th>' +
-                '<th style="width: 120px; text-align: center;">Pend. Conteúdo</th>' +
-                '<th>Datas Pendentes</th>' +
+                '<th style="width: 200px; text-align: center;">Frequências Pendentes</th>' +
+                '<th style="width: 200px; text-align: center;">Conteúdos Pendentes</th>' +
               '</tr>' +
             '</thead>' +
             '<tbody>';
 
     // Uma linha para cada disciplina
+    var recordIndex = 0;
     _.each(stepData.pending_records, function(record) {
-      // Aumentar quantidade de datas exibidas de 5 para 15
-      var maxDates = 15;
-      var frequencyDates = record.pending_frequency_dates.length > 0 ? 
-        record.pending_frequency_dates.slice(0, maxDates).join(', ') + 
-        (record.pending_frequency_dates.length > maxDates ? '...' : '') : 
-        'Nenhuma';
+      var recordId = 'record-' + stepData.step_id + '-' + recordIndex;
       
-      var contentDates = record.pending_content_dates.length > 0 ? 
-        record.pending_content_dates.slice(0, maxDates).join(', ') + 
-        (record.pending_content_dates.length > maxDates ? '...' : '') : 
-        'Nenhuma';
-
-      var frequencyBadgeClass = record.pending_frequency_count > 0 ? 'badge-danger' : 'badge-success';
-      var contentBadgeClass = record.pending_content_count > 0 ? 'badge-danger' : 'badge-success';
+      // Botão azul para frequências (com ícone de calendário)
+      var frequencyButton = record.pending_frequency_count > 0 ? 
+        '<button type="button" class="btn btn-primary toggle-dates" style="cursor: pointer; border-radius: 20px; padding: 6px 15px;" data-target="#freq-' + recordId + '">' +
+          '<i class="fa fa-calendar" style="margin-right: 5px;"></i>' +
+          record.pending_frequency_count + ' datas' +
+        '</button>' :
+        '<button type="button" class="btn btn-default" style="border-radius: 20px; padding: 6px 15px;" disabled>' +
+          '<i class="fa fa-calendar" style="margin-right: 5px;"></i>' +
+          '0 datas' +
+        '</button>';
+      
+      // Botão laranja para conteúdos (com ícone de documento/lista)
+      var contentButton = record.pending_content_count > 0 ? 
+        '<button type="button" class="btn toggle-dates" style="background-color: #ff9800; color: white; border: none; cursor: pointer; border-radius: 20px; padding: 6px 15px;" data-target="#cont-' + recordId + '">' +
+          '<i class="fa fa-file-text" style="margin-right: 5px;"></i>' +
+          record.pending_content_count + ' datas' +
+        '</button>' :
+        '<button type="button" class="btn btn-default" style="border-radius: 20px; padding: 6px 15px;" disabled>' +
+          '<i class="fa fa-file-text" style="margin-right: 5px;"></i>' +
+          '0 datas' +
+        '</button>';
 
       stepHtml += '<tr>' +
         '<td><strong>' + record.discipline + '</strong></td>' +
-        '<td style="text-align: center;"><span class="badge ' + frequencyBadgeClass + '">' + record.pending_frequency_count + '</span></td>' +
-        '<td style="text-align: center;"><span class="badge ' + contentBadgeClass + '">' + record.pending_content_count + '</span></td>' +
-        '<td>' +
-          '<strong>Freq:</strong> ' + frequencyDates + '<br>' +
-          '<strong>Cont:</strong> ' + contentDates +
+        '<td style="text-align: center;">' +
+          '<div>' +
+            frequencyButton +
+          '</div>' +
+          '<div id="freq-' + recordId + '" class="dates-container" style="display: none; margin-top: 10px; padding: 10px; background-color: #f5f5f5; border-radius: 4px; text-align: left;">' +
+            '<div class="loading-dates"><i class="fa fa-spinner fa-spin"></i> Carregando datas...</div>' +
+          '</div>' +
+        '</td>' +
+        '<td style="text-align: center;">' +
+          '<div>' +
+            contentButton +
+          '</div>' +
+          '<div id="cont-' + recordId + '" class="dates-container" style="display: none; margin-top: 10px; padding: 10px; background-color: #f5f5f5; border-radius: 4px; text-align: left;">' +
+            '<div class="loading-dates"><i class="fa fa-spinner fa-spin"></i> Carregando datas...</div>' +
+          '</div>' +
         '</td>' +
         '</tr>';
+      
+      recordIndex++;
     });
 
     stepHtml += '</tbody>' +
@@ -157,6 +184,59 @@ $(function(){
     '</div>';
 
     $stepContainer.html(stepHtml);
+    
+    // Adicionar event listeners para os ícones de lupa
+    $stepContainer.find('.toggle-dates').on('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      var targetId = $(this).data('target');
+      var $target = $(targetId);
+      
+      // Se já está visível, apenas fecha
+      if($target.is(':visible')) {
+        $target.slideUp();
+        return;
+      }
+      
+      // Fechar todos os outros containers de datas
+      $stepContainer.find('.dates-container').not($target).slideUp();
+      
+      // Se o container não tem dados carregados, buscar via AJAX
+      if($target.find('.loading-dates').length > 0 || $target.text().trim() === '' || $target.text().indexOf('Carregando') !== -1) {
+        var recordId = targetId.replace('#freq-', '').replace('#cont-', '');
+        var parts = recordId.split('-');
+        var recordIndex = parseInt(parts[parts.length - 1]); // Último elemento é o índice
+        var record = stepData.pending_records[recordIndex];
+        var isFrequency = targetId.indexOf('freq-') !== -1;
+        
+        // Mostrar loading
+        $target.html('<div class="loading-dates"><i class="fa fa-spinner fa-spin"></i> Carregando datas...</div>').slideDown();
+        
+        // Buscar datas via AJAX
+        $.ajax({
+          url: Routes.dates_dashboard_teacher_pending_records_pt_br_path({
+            format: 'json',
+            step_id: stepData.step_id,
+            discipline_id: record.discipline_id
+          }),
+          success: function(data) {
+            var dates = isFrequency ? data.pending_frequency_dates : data.pending_content_dates;
+            var label = isFrequency ? 'Datas pendentes de frequência' : 'Datas pendentes de conteúdo';
+            
+            $target.html(
+              '<strong>' + label + ':</strong><br>' +
+              (dates.length > 0 ? dates.join(', ') : 'Nenhuma')
+            );
+          },
+          error: function() {
+            $target.html('<div class="alert alert-danger">Erro ao carregar datas.</div>');
+          }
+        });
+      } else {
+        // Toggle do container atual (já tem dados)
+        $target.slideToggle();
+      }
+    });
   }
 
   function handleFetchTeacherPendingRecordsError() {

--- a/app/assets/javascripts/views/dashboard/teacher_pending_records.js
+++ b/app/assets/javascripts/views/dashboard/teacher_pending_records.js
@@ -1,0 +1,169 @@
+$(function(){
+  "use strict";
+
+  var flashMessages = new FlashMessages();
+  var $container = $('#teacher-pending-records-container');
+  var steps = [];
+
+  function fetchSteps() {
+    $.ajax({
+      beforeSend: function () {
+        $container.html('<div class="text-center"><i class="fa fa-spinner fa-spin"></i> Carregando...</div>');
+      },
+      url: Routes.dashboard_teacher_pending_records_pt_br_path({
+        format: 'json'
+      }),
+      success: handleFetchStepsSuccess,
+      error: handleFetchTeacherPendingRecordsError
+    });
+  }
+
+  function handleFetchStepsSuccess(data) {
+    steps = data.steps || [];
+    
+    if(steps.length === 0){
+      $container.html('<div class="alert alert-info">Nenhuma etapa encontrada.</div>');
+      return;
+    }
+
+    // Criar select de etapas
+    var selectHtml = '<div class="form-group">' +
+      '<label for="step-select">Selecione a etapa:</label>' +
+      '<select id="step-select" class="form-control" style="max-width: 400px;">' +
+      '<option value="">Selecione uma etapa...</option>';
+    
+    _.each(steps, function(step) {
+      selectHtml += '<option value="' + step.id + '">' + step.name + 
+        ' (' + step.start_at + ' a ' + step.end_at + ')</option>';
+    });
+    
+    selectHtml += '</select>' +
+      '</div>' +
+      '<div id="step-data-container"></div>';
+
+    $container.html(selectHtml);
+
+    // Event listener para mudança de etapa
+    $('#step-select').on('change', function() {
+      var stepId = $(this).val();
+      if(stepId) {
+        fetchStepData(stepId);
+      } else {
+        $('#step-data-container').html('');
+      }
+    });
+
+    // Selecionar etapa da data atual automaticamente
+    if(steps.length > 0) {
+      var today = new Date();
+      today.setHours(0, 0, 0, 0); // Zerar horas para comparação apenas de data
+      
+      var currentStep = null;
+      _.each(steps, function(step) {
+        var startDate = new Date(step.start_at_iso);
+        var endDate = new Date(step.end_at_iso);
+        startDate.setHours(0, 0, 0, 0);
+        endDate.setHours(0, 0, 0, 0);
+        
+        // Verificar se a data atual está dentro do período da etapa
+        if(today >= startDate && today <= endDate) {
+          currentStep = step;
+          return false; // break do loop
+        }
+      });
+      
+      // Se não encontrou etapa atual, usar a primeira etapa
+      var stepToSelect = currentStep || steps[0];
+      $('#step-select').val(stepToSelect.id).trigger('change');
+    }
+  }
+
+  function fetchStepData(stepId) {
+    var $stepContainer = $('#step-data-container');
+    
+    $.ajax({
+      beforeSend: function () {
+        $stepContainer.html('<div class="text-center"><i class="fa fa-spinner fa-spin"></i> Carregando...</div>');
+      },
+      url: Routes.dashboard_teacher_pending_records_pt_br_path({
+        format: 'json',
+        step_id: stepId
+      }),
+      success: function(data) {
+        handleFetchStepDataSuccess(data.step_data);
+      },
+      error: handleFetchTeacherPendingRecordsError
+    });
+  }
+
+  function handleFetchStepDataSuccess(stepData) {
+    var $stepContainer = $('#step-data-container');
+    
+    if(!stepData || !stepData.pending_records || stepData.pending_records.length === 0){
+      $stepContainer.html('<div class="alert alert-info">Nenhum registro pendente para esta etapa.</div>');
+      return;
+    }
+
+    var stepHtml = '<div class="panel panel-default" style="margin-top: 20px;">' +
+      '<div class="panel-heading">' +
+        '<h4 class="panel-title">' + stepData.step_name + 
+        ' <small>(' + stepData.start_at + ' a ' + stepData.end_at + ')</small></h4>' +
+      '</div>' +
+      '<div class="panel-body">' +
+        '<div class="table-responsive">' +
+          '<table class="table table-bordered table-only-inner-bordered table-striped table-hover" style="font-size: 14px;">' +
+            '<thead>' +
+              '<tr>' +
+                '<th>Disciplina</th>' +
+                '<th style="width: 120px; text-align: center;">Pend. Frequência</th>' +
+                '<th style="width: 120px; text-align: center;">Pend. Conteúdo</th>' +
+                '<th>Datas Pendentes</th>' +
+              '</tr>' +
+            '</thead>' +
+            '<tbody>';
+
+    // Uma linha para cada disciplina
+    _.each(stepData.pending_records, function(record) {
+      // Aumentar quantidade de datas exibidas de 5 para 15
+      var maxDates = 15;
+      var frequencyDates = record.pending_frequency_dates.length > 0 ? 
+        record.pending_frequency_dates.slice(0, maxDates).join(', ') + 
+        (record.pending_frequency_dates.length > maxDates ? '...' : '') : 
+        'Nenhuma';
+      
+      var contentDates = record.pending_content_dates.length > 0 ? 
+        record.pending_content_dates.slice(0, maxDates).join(', ') + 
+        (record.pending_content_dates.length > maxDates ? '...' : '') : 
+        'Nenhuma';
+
+      var frequencyBadgeClass = record.pending_frequency_count > 0 ? 'badge-danger' : 'badge-success';
+      var contentBadgeClass = record.pending_content_count > 0 ? 'badge-danger' : 'badge-success';
+
+      stepHtml += '<tr>' +
+        '<td><strong>' + record.discipline + '</strong></td>' +
+        '<td style="text-align: center;"><span class="badge ' + frequencyBadgeClass + '">' + record.pending_frequency_count + '</span></td>' +
+        '<td style="text-align: center;"><span class="badge ' + contentBadgeClass + '">' + record.pending_content_count + '</span></td>' +
+        '<td>' +
+          '<strong>Freq:</strong> ' + frequencyDates + '<br>' +
+          '<strong>Cont:</strong> ' + contentDates +
+        '</td>' +
+        '</tr>';
+    });
+
+    stepHtml += '</tbody>' +
+          '</table>' +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+    $stepContainer.html(stepHtml);
+  }
+
+  function handleFetchTeacherPendingRecordsError() {
+    $container.html('<div class="alert alert-danger">Ocorreu um erro ao buscar os dias pendentes.</div>');
+    flashMessages.error('Ocorreu um erro ao buscar os dias pendentes.');
+  }
+
+  fetchSteps();
+});
+

--- a/app/controllers/dashboard/teacher_pending_records_controller.rb
+++ b/app/controllers/dashboard/teacher_pending_records_controller.rb
@@ -3,12 +3,19 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
   before_action :require_current_classroom
 
   def index
-    return render json: { steps: [], step_data: nil } if current_user_classroom.blank? || current_teacher.blank?
+    if current_user_classroom.blank? || current_teacher.blank?
+      return render json: { steps: [], step_data: nil, has_lessons_board: false }
+    end
+
+    # Verificar se a turma tem quadro de aulas
+    has_lessons_board = LessonsBoard.by_classroom(current_user_classroom.id)
+                                    .by_year(current_school_year)
+                                    .exists?
 
     steps_fetcher = StepsFetcher.new(current_user_classroom)
     steps = steps_fetcher.steps
 
-    return render json: { steps: [], step_data: nil } if steps.blank?
+    return render json: { steps: [], step_data: nil, has_lessons_board: has_lessons_board } if steps.blank?
 
     # Retornar lista de steps para o select
     today = Date.current
@@ -31,6 +38,7 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
       
       if step
         # Buscar todas as disciplinas do professor na turma atual para esta etapa
+        # Usar count_only: true para otimizar e retornar apenas contadores
         calculator = PendingRecordsCalculator.new(
           unity_id: current_unity.id,
           classroom_id: current_user_classroom.id,
@@ -38,21 +46,22 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
           discipline_id: nil, # nil para buscar todas as disciplinas
           start_date: step.start_at,
           end_date: step.end_at,
-          school_year: current_school_year
+          school_year: current_school_year,
+          count_only: true
         )
 
         results = calculator.calculate
 
-        # Formatar os resultados para o dashboard
+        # Formatar os resultados para o dashboard (sem as datas para otimizar)
+        # Ordenar por nome da disciplina em ordem alfabética
         pending_records = results.map do |result|
           {
             discipline: result[:discipline_name],
+            discipline_id: result[:discipline_id],
             pending_frequency_count: result[:pending_frequency_count],
-            pending_content_count: result[:pending_content_count],
-            pending_frequency_dates: result[:pending_frequency_dates].map { |d| d.strftime('%d/%m/%Y') },
-            pending_content_dates: result[:pending_content_dates].map { |d| d.strftime('%d/%m/%Y') }
+            pending_content_count: result[:pending_content_count]
           }
-        end
+        end.sort_by { |record| record[:discipline] }
 
         step_data = {
           step_id: step.id,
@@ -65,7 +74,40 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
       end
     end
 
-    render json: { steps: steps_list, step_data: step_data }
+    render json: { steps: steps_list, step_data: step_data, has_lessons_board: has_lessons_board }
+  end
+
+  def dates
+    return render json: { error: 'Parâmetros inválidos' }, status: :bad_request if params[:step_id].blank? || params[:discipline_id].blank?
+
+    return render json: { error: 'Não autorizado' }, status: :unauthorized if current_user_classroom.blank? || current_teacher.blank?
+
+    steps_fetcher = StepsFetcher.new(current_user_classroom)
+    steps = steps_fetcher.steps
+    step = steps.find { |s| s.id.to_s == params[:step_id].to_s }
+
+    return render json: { error: 'Etapa não encontrada' }, status: :not_found unless step
+
+    # Buscar dados apenas da disciplina específica
+    calculator = PendingRecordsCalculator.new(
+      unity_id: current_unity.id,
+      classroom_id: current_user_classroom.id,
+      teacher_id: current_teacher.id,
+      discipline_id: params[:discipline_id],
+      start_date: step.start_at,
+      end_date: step.end_at,
+      school_year: current_school_year
+    )
+
+    results = calculator.calculate
+    result = results.first
+
+    return render json: { error: 'Disciplina não encontrada' }, status: :not_found unless result
+
+    render json: {
+      pending_frequency_dates: result[:pending_frequency_dates].map { |d| d.strftime('%d/%m/%Y') },
+      pending_content_dates: result[:pending_content_dates].map { |d| d.strftime('%d/%m/%Y') }
+    }
   end
 end
 

--- a/app/controllers/dashboard/teacher_pending_records_controller.rb
+++ b/app/controllers/dashboard/teacher_pending_records_controller.rb
@@ -57,7 +57,8 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
         pending_records = results.map do |result|
           {
             discipline: result[:discipline_name],
-            discipline_id: result[:discipline_id],
+            discipline_id: result[:discipline_id] || result[:knowledge_area_id], # Usar knowledge_area_id se discipline_id for nil
+            knowledge_area_id: result[:knowledge_area_id], # Para áreas de conhecimento
             pending_frequency_count: result[:pending_frequency_count],
             pending_content_count: result[:pending_content_count]
           }
@@ -78,7 +79,7 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
   end
 
   def dates
-    return render json: { error: 'Parâmetros inválidos' }, status: :bad_request if params[:step_id].blank? || params[:discipline_id].blank?
+    return render json: { error: 'Parâmetros inválidos' }, status: :bad_request if params[:step_id].blank? || (params[:discipline_id].blank? && params[:knowledge_area_id].blank?)
 
     return render json: { error: 'Não autorizado' }, status: :unauthorized if current_user_classroom.blank? || current_teacher.blank?
 
@@ -88,12 +89,12 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
 
     return render json: { error: 'Etapa não encontrada' }, status: :not_found unless step
 
-    # Buscar dados apenas da disciplina específica
+    # Buscar dados apenas da disciplina ou área de conhecimento específica
     calculator = PendingRecordsCalculator.new(
       unity_id: current_unity.id,
       classroom_id: current_user_classroom.id,
       teacher_id: current_teacher.id,
-      discipline_id: params[:discipline_id],
+      discipline_id: params[:discipline_id] || params[:knowledge_area_id], # Aceita ambos
       start_date: step.start_at,
       end_date: step.end_at,
       school_year: current_school_year
@@ -102,7 +103,7 @@ class Dashboard::TeacherPendingRecordsController < ApplicationController
     results = calculator.calculate
     result = results.first
 
-    return render json: { error: 'Disciplina não encontrada' }, status: :not_found unless result
+    return render json: { error: 'Disciplina/Área de conhecimento não encontrada' }, status: :not_found unless result
 
     render json: {
       pending_frequency_dates: result[:pending_frequency_dates].map { |d| d.strftime('%d/%m/%Y') },

--- a/app/controllers/dashboard/teacher_pending_records_controller.rb
+++ b/app/controllers/dashboard/teacher_pending_records_controller.rb
@@ -1,0 +1,71 @@
+class Dashboard::TeacherPendingRecordsController < ApplicationController
+  before_action :require_current_teacher
+  before_action :require_current_classroom
+
+  def index
+    return render json: { steps: [], step_data: nil } if current_user_classroom.blank? || current_teacher.blank?
+
+    steps_fetcher = StepsFetcher.new(current_user_classroom)
+    steps = steps_fetcher.steps
+
+    return render json: { steps: [], step_data: nil } if steps.blank?
+
+    # Retornar lista de steps para o select
+    today = Date.current
+    steps_list = steps.map do |step|
+      {
+        id: step.id,
+        name: step.to_s,
+        step_number: step.step_number,
+        start_at: step.start_at.strftime('%d/%m/%Y'),
+        end_at: step.end_at.strftime('%d/%m/%Y'),
+        start_at_iso: step.start_at.strftime('%Y-%m-%d'),
+        end_at_iso: step.end_at.strftime('%Y-%m-%d')
+      }
+    end
+
+    # Se step_id foi fornecido, buscar dados apenas dessa etapa
+    step_data = nil
+    if params[:step_id].present?
+      step = steps.find { |s| s.id.to_s == params[:step_id].to_s }
+      
+      if step
+        # Buscar todas as disciplinas do professor na turma atual para esta etapa
+        calculator = PendingRecordsCalculator.new(
+          unity_id: current_unity.id,
+          classroom_id: current_user_classroom.id,
+          teacher_id: current_teacher.id,
+          discipline_id: nil, # nil para buscar todas as disciplinas
+          start_date: step.start_at,
+          end_date: step.end_at,
+          school_year: current_school_year
+        )
+
+        results = calculator.calculate
+
+        # Formatar os resultados para o dashboard
+        pending_records = results.map do |result|
+          {
+            discipline: result[:discipline_name],
+            pending_frequency_count: result[:pending_frequency_count],
+            pending_content_count: result[:pending_content_count],
+            pending_frequency_dates: result[:pending_frequency_dates].map { |d| d.strftime('%d/%m/%Y') },
+            pending_content_dates: result[:pending_content_dates].map { |d| d.strftime('%d/%m/%Y') }
+          }
+        end
+
+        step_data = {
+          step_id: step.id,
+          step_name: step.to_s,
+          step_number: step.step_number,
+          start_at: step.start_at.strftime('%d/%m/%Y'),
+          end_at: step.end_at.strftime('%d/%m/%Y'),
+          pending_records: pending_records
+        }
+      end
+    end
+
+    render json: { steps: steps_list, step_data: step_data }
+  end
+end
+

--- a/app/controllers/pending_records_report_controller.rb
+++ b/app/controllers/pending_records_report_controller.rb
@@ -1,0 +1,179 @@
+class PendingRecordsReportController < ApplicationController
+  before_action :require_current_unity
+
+  def form
+    steps = steps_fetcher.steps
+    
+    @pending_records_report_form = PendingRecordsReportForm.new(
+      unity_id: current_unity.id,
+      school_calendar_year: current_school_year,
+      classroom_id: params[:classroom_id],
+      teacher_id: params[:teacher_id],
+      discipline_id: params[:discipline_id],
+      start_at: date_to_br(steps.first&.start_at || Date.current.beginning_of_year),
+      end_at: date_to_br(steps.last&.end_at || Date.current)
+    )
+
+    set_options_by_user
+    fetch_collections
+  end
+
+  def report
+    fetch_collections
+
+    @pending_records_report_form = PendingRecordsReportForm.new(resource_params)
+
+    if @pending_records_report_form.valid?
+      calculator = PendingRecordsCalculator.new(
+        unity_id: @pending_records_report_form.unity_id,
+        classroom_id: @pending_records_report_form.classroom_id,
+        teacher_id: @pending_records_report_form.teacher_id,
+        discipline_id: @pending_records_report_form.discipline_id,
+        start_date: @pending_records_report_form.start_at,
+        end_date: @pending_records_report_form.end_at,
+        school_year: @pending_records_report_form.school_calendar_year || current_school_year
+      )
+
+      @results = calculator.calculate
+
+      respond_to do |format|
+        format.html
+        format.json { render json: @results }
+      end
+    else
+      @pending_records_report_form.school_calendar_year = current_school_year
+      set_options_by_user
+      fetch_collections
+      clear_invalid_dates
+      render :form
+    end
+  end
+
+  def classroom_teachers
+    return render json: { teachers: [] } if params[:classroom_id].blank?
+
+    classroom = Classroom.find(params[:classroom_id])
+    school_year = current_school_year || Date.current.year
+    teachers = Teacher.joins(:teacher_discipline_classrooms)
+                     .where(teacher_discipline_classrooms: { 
+                       classroom_id: classroom.id,
+                       year: school_year
+                     })
+                     .distinct
+                     .order_by_name
+
+    render json: { 
+      teachers: teachers.map { |t| { id: t.id, name: t.name } }
+    }
+  end
+
+  def classroom_disciplines
+    return render json: { disciplines: [] } if params[:classroom_id].blank?
+
+    classroom = Classroom.find(params[:classroom_id])
+    school_year = current_school_year || Date.current.year
+    disciplines = Discipline.joins(:teacher_discipline_classrooms)
+                           .where(teacher_discipline_classrooms: { 
+                             classroom_id: classroom.id,
+                             year: school_year
+                           })
+                           .distinct
+                           .ordered
+
+    render json: { 
+      disciplines: disciplines.map { |d| { id: d.id, description: d.to_s } }
+    }
+  end
+
+  private
+
+  def steps_fetcher
+    @steps_fetcher ||= begin
+      classroom = @pending_records_report_form&.classroom_id.present? ? 
+        Classroom.find(@pending_records_report_form.classroom_id) : 
+        current_user_classroom
+      StepsFetcher.new(classroom || Classroom.new)
+    end
+  end
+
+  def fetch_collections
+    @school_year = current_school_year
+  end
+
+  def resource_params
+    params.require(:pending_records_report_form).permit(
+      :unity_id,
+      :classroom_id,
+      :teacher_id,
+      :discipline_id,
+      :start_at,
+      :end_at,
+      :school_calendar_year
+    )
+  end
+
+  def clear_invalid_dates
+    begin
+      resource_params[:start_at].to_date
+    rescue ArgumentError
+      @pending_records_report_form.start_at = ''
+    end
+
+    begin
+      resource_params[:end_at].to_date
+    rescue ArgumentError
+      @pending_records_report_form.end_at = ''
+    end
+  end
+
+  def set_options_by_user
+    @admin_or_teacher ||= current_user.current_role_is_admin_or_employee?
+    @unities ||= @admin_or_teacher ? Unity.ordered : [current_user_unity]
+
+    return fetch_linked_by_teacher unless @admin_or_teacher
+
+      @classrooms = Classroom.by_unity(@pending_records_report_form.unity_id)
+                           .by_year(current_school_year || Date.current.year)
+                           .ordered
+
+    if @pending_records_report_form.classroom_id.present?
+      @teachers = Teacher.joins(:teacher_discipline_classrooms)
+                        .where(teacher_discipline_classrooms: { 
+                          classroom_id: @pending_records_report_form.classroom_id,
+                          year: current_school_year || Date.current.year
+                        })
+                        .distinct
+                        .order_by_name
+
+      @disciplines = Discipline.joins(:teacher_discipline_classrooms)
+                              .where(teacher_discipline_classrooms: { 
+                                classroom_id: @pending_records_report_form.classroom_id,
+                                year: current_school_year || Date.current.year
+                              })
+                              .distinct
+                              .ordered
+    else
+      @teachers = []
+      @disciplines = []
+    end
+  end
+
+  def fetch_linked_by_teacher
+    return unless current_teacher
+
+    @fetch_linked_by_teacher ||= TeacherClassroomAndDisciplineFetcher.fetch!(
+      current_teacher.id, 
+      current_unity, 
+      current_school_year
+    )
+    @classrooms = @fetch_linked_by_teacher[:classrooms]
+    
+    classroom_id = @pending_records_report_form.classroom_id || current_user_classroom&.id
+    @disciplines = @fetch_linked_by_teacher[:disciplines]
+                  .by_classroom_id(classroom_id)
+                  .not_descriptor if classroom_id.present?
+    
+    @teachers = [current_teacher] if current_teacher
+  end
+end
+

--- a/app/forms/pending_records_report_form.rb
+++ b/app/forms/pending_records_report_form.rb
@@ -1,0 +1,21 @@
+class PendingRecordsReportForm
+  include ActiveModel::Model
+
+  attr_accessor :unity_id,
+                :classroom_id,
+                :teacher_id,
+                :discipline_id,
+                :start_at,
+                :end_at,
+                :school_calendar_year
+
+  validates :start_at, presence: true, date: true, timeliness: {
+    on_or_before: :end_at, type: :date, on_or_before_message: I18n.t('errors.messages.on_or_before_message')
+  }
+  validates :end_at, presence: true, date: true, timeliness: {
+    on_or_after: :start_at, type: :date, on_or_after_message: I18n.t('errors.messages.on_or_after_message')
+  }
+  validates :unity_id, presence: true
+  validates :school_calendar_year, presence: true
+end
+

--- a/app/services/pending_records_calculator.rb
+++ b/app/services/pending_records_calculator.rb
@@ -1,5 +1,5 @@
 class PendingRecordsCalculator
-  def initialize(unity_id: nil, classroom_id: nil, teacher_id: nil, discipline_id: nil, start_date: nil, end_date: nil, school_year: nil)
+  def initialize(unity_id: nil, classroom_id: nil, teacher_id: nil, discipline_id: nil, start_date: nil, end_date: nil, school_year: nil, count_only: false)
     @unity_id = unity_id
     @classroom_id = classroom_id
     @teacher_id = teacher_id
@@ -7,6 +7,7 @@ class PendingRecordsCalculator
     @start_date = start_date || Date.current.beginning_of_year
     @end_date = end_date || Date.current
     @school_year = school_year || Date.current.year
+    @count_only = count_only
   end
 
   def calculate
@@ -32,6 +33,9 @@ class PendingRecordsCalculator
         end_date = [steps.map(&:end_at).max, @end_date].min
       end
 
+      # Verificar se é turma infantil
+      is_infantil = is_infantil_classroom?(classroom)
+
       # Obter frequency_type da turma
       # Usar o primeiro teacher_id para determinar o frequency_type (todos os professores da mesma turma têm o mesmo tipo)
       first_teacher_id = tdcs.first.teacher_id
@@ -39,6 +43,17 @@ class PendingRecordsCalculator
       frequency_type_definer.define!
       frequency_type = frequency_type_definer.frequency_type
       is_general_frequency = frequency_type == FrequencyTypes::GENERAL
+
+      # Se for turma infantil, buscar áreas de conhecimento ao invés de disciplinas
+      if is_infantil
+        # Buscar áreas de conhecimento do professor na turma
+        knowledge_area_ids = KnowledgeArea.by_teacher(@teacher_id)
+                                         .by_classroom_id(classroom.id)
+                                         .pluck(:id)
+        
+        # Para turmas infantis, processar por área de conhecimento
+        return process_infantil_classroom(classroom, knowledge_area_ids, school_calendar, start_date, end_date, is_general_frequency, all_school_days, today, grade_id)
+      end
 
       # Buscar weekdays em batch para todas as disciplinas (sempre necessário para conteúdos)
       discipline_ids = tdcs.map { |tdc| tdc.discipline_id }.uniq
@@ -48,74 +63,154 @@ class PendingRecordsCalculator
       today = Date.current
       grade_id = classroom.grade_ids.first
 
+      # Calcular dias letivos UMA VEZ para todas as disciplinas da turma
+      # Usar a primeira disciplina (geralmente todas têm as mesmas regras de calendário)
+      first_discipline_id = tdcs.first.discipline_id
+      school_day_checker = SchoolDayChecker.new(school_calendar, start_date, grade_id, classroom.id, first_discipline_id)
+      all_school_days = school_day_checker.school_dates_between(start_date, end_date)
+
+      # Buscar frequências e conteúdos em batch para todas as disciplinas (otimização)
+      teacher_ids = tdcs.map { |tdc| tdc.teacher_id }.uniq
+      all_frequencies_by_teacher_discipline = {}
+      all_contents_by_teacher_discipline = {}
+      
+      teacher_ids.each do |teacher_id|
+        if is_general_frequency
+          # Frequências gerais: buscar uma vez para todas as disciplinas
+          general_freq_dates = DailyFrequency
+            .by_owner_teacher_id(teacher_id)
+            .by_classroom_id(classroom.id)
+            .general_frequency
+            .by_frequency_date_between(start_date, end_date)
+            .where('frequency_date <= ?', today)
+            .pluck(:frequency_date)
+            .map(&:to_date)
+            .to_set
+          
+          # Para frequências gerais, todas as disciplinas usam o mesmo conjunto
+          all_frequencies_by_teacher_discipline[teacher_id] = { general: general_freq_dates }
+        else
+          # Frequências por disciplina: buscar todas de uma vez
+          frequency_data = DailyFrequency
+            .by_owner_teacher_id(teacher_id)
+            .by_classroom_id(classroom.id)
+            .where(discipline_id: discipline_ids)
+            .by_frequency_date_between(start_date, end_date)
+            .where('frequency_date <= ?', today)
+            .pluck(:discipline_id, :frequency_date)
+          
+          all_frequencies_by_teacher_discipline[teacher_id] = frequency_data
+            .group_by { |d| d[0] }
+            .transform_values { |dates| dates.map { |d| d[1].to_date }.to_set }
+        end
+        
+        # Conteúdos: buscar todos de uma vez para todas as disciplinas
+        content_data = DisciplineContentRecord
+          .by_teacher_id(teacher_id)
+          .by_classroom_id(classroom.id)
+          .where(discipline_id: discipline_ids)
+          .by_date_range(start_date, end_date)
+          .joins(:content_record)
+          .where('content_records.record_date <= ?', today)
+          .pluck(:discipline_id, 'content_records.record_date')
+        
+        all_contents_by_teacher_discipline[teacher_id] = content_data
+          .group_by { |d| d[0] }
+          .transform_values { |dates| dates.map { |d| d[1].to_date }.to_set }
+      end
+
       tdcs.each do |tdc|
         teacher = tdc.teacher
         discipline = tdc.discipline
-
-        # Obter dias letivos no período (uma vez por disciplina)
-        school_day_checker = SchoolDayChecker.new(school_calendar, start_date, grade_id, classroom.id, discipline.id)
-        all_school_days = school_day_checker.school_dates_between(start_date, end_date)
 
         # Para frequências: se for GENERAL, usar todos os dias letivos (não filtrar por weekdays)
         # Se for BY_DISCIPLINE, filtrar por weekdays da disciplina
         # Para conteúdos: sempre filtrar por weekdays da disciplina
         discipline_weekdays = all_weekdays[discipline.id] || []
         
+        # Mapear weekdays para números (0=domingo, 1=segunda, etc)
+        weekday_numbers = discipline_weekdays.map do |wd|
+          case wd
+          when 'sunday' then 0
+          when 'monday' then 1
+          when 'tuesday' then 2
+          when 'wednesday' then 3
+          when 'thursday' then 4
+          when 'friday' then 5
+          when 'saturday' then 6
+          end
+        end.compact
+        
         if discipline_weekdays.empty?
           school_days_for_content = []
           school_days_for_frequency = is_general_frequency ? all_school_days : []
         else
           # Filtrar apenas os dias letivos que correspondem aos dias da semana da disciplina
-          school_days_for_content = all_school_days.select do |date|
-            weekday_name = date.strftime("%A").downcase
-            discipline_weekdays.include?(weekday_name)
-          end
+          school_days_for_content = all_school_days.select { |date| weekday_numbers.include?(date.wday) }
           
           # Para frequências: se for GENERAL, usar todos os dias letivos; senão, usar os dias da disciplina
           school_days_for_frequency = is_general_frequency ? all_school_days : school_days_for_content
         end
 
-        # Obter frequências registradas
-        if is_general_frequency
-          # Se for frequência geral, buscar frequências gerais (discipline_id: nil) que servem para todas as disciplinas
-          frequencies = DailyFrequency
-            .by_owner_teacher_id(teacher.id)
-            .by_classroom_id(classroom.id)
-            .general_frequency  # discipline_id: nil, class_number: nil
-            .by_frequency_date_between(start_date, end_date)
-            .pluck(:frequency_date)
-            .map(&:to_date)
+        # Obter frequências registradas (usar dados já carregados em batch)
+        if @count_only
+          # Modo otimizado: usar dados já carregados em batch
+          if is_general_frequency
+            frequency_dates_set = all_frequencies_by_teacher_discipline[teacher.id]&.dig(:general) || Set.new
+          else
+            frequency_dates_set = all_frequencies_by_teacher_discipline[teacher.id]&.dig(discipline.id) || Set.new
+          end
+
+          content_dates_set = all_contents_by_teacher_discipline[teacher.id]&.dig(discipline.id) || Set.new
+
+          # Calcular apenas contadores
+          pending_frequency_dates = []
+          pending_frequency_count = school_days_for_frequency.count { |date| date <= today && !frequency_dates_set.include?(date) }
+          
+          pending_content_dates = []
+          pending_content_count = school_days_for_content.count { |date| date <= today && !content_dates_set.include?(date) }
         else
-          # Se for frequência por disciplina, buscar frequências específicas da disciplina
-          frequencies = DailyFrequency
-            .by_owner_teacher_id(teacher.id)
+          # Modo completo: buscar todas as datas
+          if is_general_frequency
+            frequencies = DailyFrequency
+              .by_owner_teacher_id(teacher.id)
+              .by_classroom_id(classroom.id)
+              .general_frequency
+              .by_frequency_date_between(start_date, end_date)
+              .pluck(:frequency_date)
+              .map(&:to_date)
+          else
+            frequencies = DailyFrequency
+              .by_owner_teacher_id(teacher.id)
+              .by_classroom_id(classroom.id)
+              .by_discipline_id(discipline.id)
+              .by_frequency_date_between(start_date, end_date)
+              .pluck(:frequency_date)
+              .map(&:to_date)
+          end
+
+          content_records = DisciplineContentRecord
+            .by_teacher_id(teacher.id)
             .by_classroom_id(classroom.id)
             .by_discipline_id(discipline.id)
-            .by_frequency_date_between(start_date, end_date)
-            .pluck(:frequency_date)
+            .by_date_range(start_date, end_date)
+            .joins(:content_record)
+            .pluck('content_records.record_date')
             .map(&:to_date)
+
+          # Calcular dias pendentes
+          pending_frequency_dates = (school_days_for_frequency - frequencies).select { |date| date <= today }
+          pending_content_dates = (school_days_for_content - content_records).select { |date| date <= today }
+          pending_frequency_count = pending_frequency_dates.count
+          pending_content_count = pending_content_dates.count
         end
-
-        # Obter conteúdos registrados (sempre considerar disciplinas do quadro de aulas)
-        content_records = DisciplineContentRecord
-          .by_teacher_id(teacher.id)
-          .by_classroom_id(classroom.id)
-          .by_discipline_id(discipline.id)
-          .by_date_range(start_date, end_date)
-          .joins(:content_record)
-          .pluck('content_records.record_date')
-          .map(&:to_date)
-
-        # Calcular dias pendentes
-        pending_frequency_dates = (school_days_for_frequency - frequencies).select { |date| date <= today }
-        pending_content_dates = (school_days_for_content - content_records).select { |date| date <= today }
 
         # Calcular carga horária total (usar school_days_for_content para cálculo)
         weekly_hours = calculate_weekly_hours(classroom.id, discipline.id, tdc.period)
         weeks_in_period = calculate_weeks_in_period(start_date, end_date, school_days_for_content)
         total_workload = weekly_hours * weeks_in_period
 
-        results << {
+        result = {
           teacher_id: teacher.id,
           teacher_name: teacher.name,
           discipline_id: discipline.id,
@@ -126,11 +221,17 @@ class PendingRecordsCalculator
           unity_name: unity.name,
           period: tdc.period,
           total_workload: total_workload,
-          pending_frequency_dates: pending_frequency_dates.sort,
-          pending_content_dates: pending_content_dates.sort,
-          pending_frequency_count: pending_frequency_dates.count,
-          pending_content_count: pending_content_dates.count
+          pending_frequency_count: pending_frequency_count,
+          pending_content_count: pending_content_count
         }
+        
+        # Só incluir as datas se não estiver em modo count_only
+        unless @count_only
+          result[:pending_frequency_dates] = pending_frequency_dates.sort
+          result[:pending_content_dates] = pending_content_dates.sort
+        end
+        
+        results << result
       end
     end
 
@@ -234,6 +335,132 @@ class PendingRecordsCalculator
     # Método mantido para compatibilidade, mas agora usa o método otimizado
     all_weekdays = get_all_disciplines_weekdays(classroom_id, [discipline_id], [period])
     all_weekdays[discipline_id] || []
+  end
+
+  def is_infantil_classroom?(classroom)
+    classroom.classrooms_grades.any? do |classroom_grade|
+      grade = classroom_grade.grade
+      grade&.description&.match?(/creche|pre|pre-escola|pré|pré-escola|maternal|bercario|berçario|infantil|aee/i)
+    end
+  end
+
+  def process_infantil_classroom(classroom, knowledge_area_ids, school_calendar, start_date, end_date, is_general_frequency, all_school_days, today, grade_id)
+    results = []
+    
+    return results if knowledge_area_ids.blank?
+
+    # Para turmas infantis, não há quadro de aulas por disciplina/área de conhecimento
+    # Então usamos todos os dias letivos para conteúdos
+    school_days_for_content = all_school_days
+    school_days_for_frequency = is_general_frequency ? all_school_days : []
+
+    # Buscar frequências em batch
+    teacher_frequencies = {}
+    if is_general_frequency
+      general_freq_dates = DailyFrequency
+        .by_owner_teacher_id(@teacher_id)
+        .by_classroom_id(classroom.id)
+        .general_frequency
+        .by_frequency_date_between(start_date, end_date)
+        .where('frequency_date <= ?', today)
+        .pluck(:frequency_date)
+        .map(&:to_date)
+        .to_set
+      
+      teacher_frequencies[@teacher_id] = { general: general_freq_dates }
+    end
+
+    # Buscar conteúdos por área de conhecimento em batch
+    content_data = KnowledgeAreaContentRecord
+      .by_teacher_id(@teacher_id)
+      .by_classroom_id(classroom.id)
+      .by_knowledge_area_id(knowledge_area_ids)
+      .by_date_range(start_date, end_date)
+      .joins(:content_record)
+      .joins(:knowledge_areas)
+      .where('content_records.record_date <= ?', today)
+      .pluck('knowledge_areas.id', 'content_records.record_date')
+    
+    all_contents_by_knowledge_area = content_data
+      .group_by { |d| d[0] }
+      .transform_values { |dates| dates.map { |d| d[1].to_date }.to_set }
+
+    # Processar cada área de conhecimento
+    knowledge_area_ids.each do |knowledge_area_id|
+      knowledge_area = KnowledgeArea.find_by(id: knowledge_area_id)
+      next unless knowledge_area
+
+      # Obter frequências registradas
+      if @count_only
+        if is_general_frequency
+          frequency_dates_set = teacher_frequencies[@teacher_id]&.dig(:general) || Set.new
+        else
+          frequency_dates_set = Set.new # Turmas infantis geralmente usam frequência geral
+        end
+
+        content_dates_set = all_contents_by_knowledge_area[knowledge_area_id] || Set.new
+
+        # Calcular apenas contadores
+        pending_frequency_count = school_days_for_frequency.count { |date| date <= today && !frequency_dates_set.include?(date) }
+        pending_content_count = school_days_for_content.count { |date| date <= today && !content_dates_set.include?(date) }
+      else
+        # Modo completo: buscar todas as datas
+        if is_general_frequency
+          frequencies = DailyFrequency
+            .by_owner_teacher_id(@teacher_id)
+            .by_classroom_id(classroom.id)
+            .general_frequency
+            .by_frequency_date_between(start_date, end_date)
+            .pluck(:frequency_date)
+            .map(&:to_date)
+        else
+          frequencies = []
+        end
+
+        content_records = KnowledgeAreaContentRecord
+          .by_teacher_id(@teacher_id)
+          .by_classroom_id(classroom.id)
+          .by_knowledge_area_id(knowledge_area_id)
+          .by_date_range(start_date, end_date)
+          .joins(:content_record)
+          .pluck('content_records.record_date')
+          .map(&:to_date)
+
+        pending_frequency_dates = (school_days_for_frequency - frequencies).select { |date| date <= today }
+        pending_content_dates = (school_days_for_content - content_records).select { |date| date <= today }
+        pending_frequency_count = pending_frequency_dates.count
+        pending_content_count = pending_content_dates.count
+      end
+
+      # Calcular carga horária (para turmas infantis, usar aproximação)
+      weekly_hours = 0 # Turmas infantis não têm quadro de aulas
+      weeks_in_period = calculate_weeks_in_period(start_date, end_date, school_days_for_content)
+      total_workload = weekly_hours * weeks_in_period
+
+      result = {
+        teacher_id: @teacher_id,
+        teacher_name: User.find_by(teacher_id: @teacher_id)&.name || '',
+        discipline_id: nil, # Para áreas de conhecimento, não há discipline_id
+        discipline_name: knowledge_area.to_s,
+        classroom_id: classroom.id,
+        classroom_name: classroom.description,
+        unity_id: classroom.unity.id,
+        unity_name: classroom.unity.name,
+        period: nil,
+        total_workload: total_workload,
+        pending_frequency_count: pending_frequency_count,
+        pending_content_count: pending_content_count
+      }
+      
+      unless @count_only
+        result[:pending_frequency_dates] = pending_frequency_dates.sort
+        result[:pending_content_dates] = pending_content_dates.sort
+      end
+      
+      results << result
+    end
+
+    results
   end
 end
 

--- a/app/services/pending_records_calculator.rb
+++ b/app/services/pending_records_calculator.rb
@@ -33,9 +33,6 @@ class PendingRecordsCalculator
         end_date = [steps.map(&:end_at).max, @end_date].min
       end
 
-      # Verificar se é turma infantil
-      is_infantil = is_infantil_classroom?(classroom)
-
       # Obter frequency_type da turma
       # Usar o primeiro teacher_id para determinar o frequency_type (todos os professores da mesma turma têm o mesmo tipo)
       first_teacher_id = tdcs.first.teacher_id
@@ -44,22 +41,6 @@ class PendingRecordsCalculator
       frequency_type = frequency_type_definer.frequency_type
       is_general_frequency = frequency_type == FrequencyTypes::GENERAL
 
-      # Se for turma infantil, buscar áreas de conhecimento ao invés de disciplinas
-      if is_infantil
-        # Buscar áreas de conhecimento do professor na turma
-        knowledge_area_ids = KnowledgeArea.by_teacher(@teacher_id)
-                                         .by_classroom_id(classroom.id)
-                                         .pluck(:id)
-        
-        # Para turmas infantis, processar por área de conhecimento
-        return process_infantil_classroom(classroom, knowledge_area_ids, school_calendar, start_date, end_date, is_general_frequency, all_school_days, today, grade_id)
-      end
-
-      # Buscar weekdays em batch para todas as disciplinas (sempre necessário para conteúdos)
-      discipline_ids = tdcs.map { |tdc| tdc.discipline_id }.uniq
-      periods = tdcs.map(&:period).uniq
-      all_weekdays = get_all_disciplines_weekdays(classroom.id, discipline_ids, periods)
-      
       today = Date.current
       grade_id = classroom.grade_ids.first
 
@@ -68,6 +49,32 @@ class PendingRecordsCalculator
       first_discipline_id = tdcs.first.discipline_id
       school_day_checker = SchoolDayChecker.new(school_calendar, start_date, grade_id, classroom.id, first_discipline_id)
       all_school_days = school_day_checker.school_dates_between(start_date, end_date)
+
+      # Verificar se é turma infantil
+      is_infantil = is_infantil_classroom?(classroom)
+
+      # Se for turma infantil, buscar áreas de conhecimento ao invés de disciplinas
+      if is_infantil
+        # Buscar áreas de conhecimento do professor na turma
+        teacher_id = tdcs.first.teacher_id
+        knowledge_area_ids = KnowledgeArea.by_teacher(teacher_id)
+                                         .by_classroom_id(classroom.id)
+                                         .pluck(:id)
+        
+        # Se discipline_id foi fornecido e é um ID de área de conhecimento, filtrar
+        if @discipline_id.present?
+          knowledge_area_ids = knowledge_area_ids.select { |id| id.to_s == @discipline_id.to_s }
+        end
+        
+        # Para turmas infantis, processar por área de conhecimento
+        results.concat(process_infantil_classroom(classroom, knowledge_area_ids, school_calendar, start_date, end_date, is_general_frequency, all_school_days, today, grade_id, teacher_id))
+        next # Pular processamento normal de disciplinas
+      end
+
+      # Buscar weekdays em batch para todas as disciplinas (sempre necessário para conteúdos)
+      discipline_ids = tdcs.map { |tdc| tdc.discipline_id }.uniq
+      periods = tdcs.map(&:period).uniq
+      all_weekdays = get_all_disciplines_weekdays(classroom.id, discipline_ids, periods)
 
       # Buscar frequências e conteúdos em batch para todas as disciplinas (otimização)
       teacher_ids = tdcs.map { |tdc| tdc.teacher_id }.uniq
@@ -344,10 +351,13 @@ class PendingRecordsCalculator
     end
   end
 
-  def process_infantil_classroom(classroom, knowledge_area_ids, school_calendar, start_date, end_date, is_general_frequency, all_school_days, today, grade_id)
+  def process_infantil_classroom(classroom, knowledge_area_ids, school_calendar, start_date, end_date, is_general_frequency, all_school_days, today, grade_id, teacher_id)
     results = []
     
     return results if knowledge_area_ids.blank?
+
+    teacher = Teacher.find_by(id: teacher_id)
+    return results unless teacher
 
     # Para turmas infantis, não há quadro de aulas por disciplina/área de conhecimento
     # Então usamos todos os dias letivos para conteúdos
@@ -358,7 +368,7 @@ class PendingRecordsCalculator
     teacher_frequencies = {}
     if is_general_frequency
       general_freq_dates = DailyFrequency
-        .by_owner_teacher_id(@teacher_id)
+        .by_owner_teacher_id(teacher_id)
         .by_classroom_id(classroom.id)
         .general_frequency
         .by_frequency_date_between(start_date, end_date)
@@ -367,12 +377,12 @@ class PendingRecordsCalculator
         .map(&:to_date)
         .to_set
       
-      teacher_frequencies[@teacher_id] = { general: general_freq_dates }
+      teacher_frequencies[teacher_id] = { general: general_freq_dates }
     end
 
     # Buscar conteúdos por área de conhecimento em batch
     content_data = KnowledgeAreaContentRecord
-      .by_teacher_id(@teacher_id)
+      .by_teacher_id(teacher_id)
       .by_classroom_id(classroom.id)
       .by_knowledge_area_id(knowledge_area_ids)
       .by_date_range(start_date, end_date)
@@ -393,7 +403,7 @@ class PendingRecordsCalculator
       # Obter frequências registradas
       if @count_only
         if is_general_frequency
-          frequency_dates_set = teacher_frequencies[@teacher_id]&.dig(:general) || Set.new
+          frequency_dates_set = teacher_frequencies[teacher_id]&.dig(:general) || Set.new
         else
           frequency_dates_set = Set.new # Turmas infantis geralmente usam frequência geral
         end
@@ -407,7 +417,7 @@ class PendingRecordsCalculator
         # Modo completo: buscar todas as datas
         if is_general_frequency
           frequencies = DailyFrequency
-            .by_owner_teacher_id(@teacher_id)
+            .by_owner_teacher_id(teacher_id)
             .by_classroom_id(classroom.id)
             .general_frequency
             .by_frequency_date_between(start_date, end_date)
@@ -418,7 +428,7 @@ class PendingRecordsCalculator
         end
 
         content_records = KnowledgeAreaContentRecord
-          .by_teacher_id(@teacher_id)
+          .by_teacher_id(teacher_id)
           .by_classroom_id(classroom.id)
           .by_knowledge_area_id(knowledge_area_id)
           .by_date_range(start_date, end_date)
@@ -438,9 +448,10 @@ class PendingRecordsCalculator
       total_workload = weekly_hours * weeks_in_period
 
       result = {
-        teacher_id: @teacher_id,
-        teacher_name: User.find_by(teacher_id: @teacher_id)&.name || '',
+        teacher_id: teacher_id,
+        teacher_name: teacher.name,
         discipline_id: nil, # Para áreas de conhecimento, não há discipline_id
+        knowledge_area_id: knowledge_area_id, # ID da área de conhecimento
         discipline_name: knowledge_area.to_s,
         classroom_id: classroom.id,
         classroom_name: classroom.description,

--- a/app/services/pending_records_calculator.rb
+++ b/app/services/pending_records_calculator.rb
@@ -1,0 +1,239 @@
+class PendingRecordsCalculator
+  def initialize(unity_id: nil, classroom_id: nil, teacher_id: nil, discipline_id: nil, start_date: nil, end_date: nil, school_year: nil)
+    @unity_id = unity_id
+    @classroom_id = classroom_id
+    @teacher_id = teacher_id
+    @discipline_id = discipline_id
+    @start_date = start_date || Date.current.beginning_of_year
+    @end_date = end_date || Date.current
+    @school_year = school_year || Date.current.year
+  end
+
+  def calculate
+    results = []
+    
+    # Agrupar por classroom para otimizar queries
+    tdcs_by_classroom = teacher_discipline_classrooms.group_by { |tdc| tdc.classroom }
+    
+    tdcs_by_classroom.each do |classroom, tdcs|
+      # Cachear dados comuns da turma
+      unity = classroom.unity
+      school_calendar = CurrentSchoolCalendarFetcher.new(unity, classroom, @school_year).fetch
+      next unless school_calendar
+
+      steps_fetcher = StepsFetcher.new(classroom)
+      steps = steps_fetcher.steps_by_date_range(@start_date, @end_date)
+      
+      if steps.blank?
+        start_date = @start_date
+        end_date = @end_date
+      else
+        start_date = [steps.map(&:start_at).min, @start_date].max
+        end_date = [steps.map(&:end_at).max, @end_date].min
+      end
+
+      # Obter frequency_type da turma
+      # Usar o primeiro teacher_id para determinar o frequency_type (todos os professores da mesma turma têm o mesmo tipo)
+      first_teacher_id = tdcs.first.teacher_id
+      frequency_type_definer = FrequencyTypeDefiner.new(classroom, first_teacher_id, nil, year: @school_year)
+      frequency_type_definer.define!
+      frequency_type = frequency_type_definer.frequency_type
+      is_general_frequency = frequency_type == FrequencyTypes::GENERAL
+
+      # Buscar weekdays em batch para todas as disciplinas (sempre necessário para conteúdos)
+      discipline_ids = tdcs.map { |tdc| tdc.discipline_id }.uniq
+      periods = tdcs.map(&:period).uniq
+      all_weekdays = get_all_disciplines_weekdays(classroom.id, discipline_ids, periods)
+      
+      today = Date.current
+      grade_id = classroom.grade_ids.first
+
+      tdcs.each do |tdc|
+        teacher = tdc.teacher
+        discipline = tdc.discipline
+
+        # Obter dias letivos no período (uma vez por disciplina)
+        school_day_checker = SchoolDayChecker.new(school_calendar, start_date, grade_id, classroom.id, discipline.id)
+        all_school_days = school_day_checker.school_dates_between(start_date, end_date)
+
+        # Para frequências: se for GENERAL, usar todos os dias letivos (não filtrar por weekdays)
+        # Se for BY_DISCIPLINE, filtrar por weekdays da disciplina
+        # Para conteúdos: sempre filtrar por weekdays da disciplina
+        discipline_weekdays = all_weekdays[discipline.id] || []
+        
+        if discipline_weekdays.empty?
+          school_days_for_content = []
+          school_days_for_frequency = is_general_frequency ? all_school_days : []
+        else
+          # Filtrar apenas os dias letivos que correspondem aos dias da semana da disciplina
+          school_days_for_content = all_school_days.select do |date|
+            weekday_name = date.strftime("%A").downcase
+            discipline_weekdays.include?(weekday_name)
+          end
+          
+          # Para frequências: se for GENERAL, usar todos os dias letivos; senão, usar os dias da disciplina
+          school_days_for_frequency = is_general_frequency ? all_school_days : school_days_for_content
+        end
+
+        # Obter frequências registradas
+        if is_general_frequency
+          # Se for frequência geral, buscar frequências gerais (discipline_id: nil) que servem para todas as disciplinas
+          frequencies = DailyFrequency
+            .by_owner_teacher_id(teacher.id)
+            .by_classroom_id(classroom.id)
+            .general_frequency  # discipline_id: nil, class_number: nil
+            .by_frequency_date_between(start_date, end_date)
+            .pluck(:frequency_date)
+            .map(&:to_date)
+        else
+          # Se for frequência por disciplina, buscar frequências específicas da disciplina
+          frequencies = DailyFrequency
+            .by_owner_teacher_id(teacher.id)
+            .by_classroom_id(classroom.id)
+            .by_discipline_id(discipline.id)
+            .by_frequency_date_between(start_date, end_date)
+            .pluck(:frequency_date)
+            .map(&:to_date)
+        end
+
+        # Obter conteúdos registrados (sempre considerar disciplinas do quadro de aulas)
+        content_records = DisciplineContentRecord
+          .by_teacher_id(teacher.id)
+          .by_classroom_id(classroom.id)
+          .by_discipline_id(discipline.id)
+          .by_date_range(start_date, end_date)
+          .joins(:content_record)
+          .pluck('content_records.record_date')
+          .map(&:to_date)
+
+        # Calcular dias pendentes
+        pending_frequency_dates = (school_days_for_frequency - frequencies).select { |date| date <= today }
+        pending_content_dates = (school_days_for_content - content_records).select { |date| date <= today }
+
+        # Calcular carga horária total (usar school_days_for_content para cálculo)
+        weekly_hours = calculate_weekly_hours(classroom.id, discipline.id, tdc.period)
+        weeks_in_period = calculate_weeks_in_period(start_date, end_date, school_days_for_content)
+        total_workload = weekly_hours * weeks_in_period
+
+        results << {
+          teacher_id: teacher.id,
+          teacher_name: teacher.name,
+          discipline_id: discipline.id,
+          discipline_name: discipline.to_s,
+          classroom_id: classroom.id,
+          classroom_name: classroom.description,
+          unity_id: unity.id,
+          unity_name: unity.name,
+          period: tdc.period,
+          total_workload: total_workload,
+          pending_frequency_dates: pending_frequency_dates.sort,
+          pending_content_dates: pending_content_dates.sort,
+          pending_frequency_count: pending_frequency_dates.count,
+          pending_content_count: pending_content_dates.count
+        }
+      end
+    end
+
+    results
+  end
+
+  private
+
+  def teacher_discipline_classrooms
+    relation = TeacherDisciplineClassroom
+      .includes(:teacher, :discipline, classroom: :unity)
+      .joins(:classroom)
+      .by_year(@school_year)
+
+    relation = relation.where(classrooms: { unity_id: @unity_id }) if @unity_id.present?
+    relation = relation.by_classroom(@classroom_id) if @classroom_id.present?
+    relation = relation.by_teacher_id(@teacher_id) if @teacher_id.present?
+    relation = relation.by_discipline_id(@discipline_id) if @discipline_id.present?
+
+    relation
+  end
+
+  def calculate_weekly_hours(classroom_id, discipline_id, period)
+    # Contar aulas semanais da disciplina no quadro de horários
+    # Cada registro representa uma aula em um dia da semana
+    count = LessonsBoardLessonWeekday
+      .joins(teacher_discipline_classroom: [:discipline, :classroom])
+      .joins(lessons_board_lesson: [:lessons_board])
+      .where(classrooms: { id: classroom_id })
+      .where(disciplines: { id: discipline_id })
+      .where(lessons_boards: { period: period })
+      .where(teacher_discipline_classrooms: { active: true })
+      .where(teacher_discipline_classrooms: { discarded_at: nil })
+      .count
+    
+    # Se não encontrar no quadro de horários, retorna 0
+    count > 0 ? count : 0
+  end
+
+  def calculate_weeks_in_period(start_date, end_date, school_days)
+    # Calcular número de semanas baseado nos dias letivos
+    # Aproximação: dividir dias letivos por 5 (dias úteis da semana)
+    return 0 if school_days.empty?
+    
+    weeks = (school_days.count.to_f / 5.0).ceil
+    [weeks, 1].max # Mínimo de 1 semana
+  end
+
+  def get_all_disciplines_weekdays(classroom_id, discipline_ids, periods)
+    # Buscar todos os weekdays de uma vez para todas as disciplinas
+    # Retorna um hash: { discipline_id => [weekdays] }
+    
+    result = {}
+    
+    # Primeiro tenta com período específico
+    weekdays_data = LessonsBoardLessonWeekday
+      .joins(lessons_board_lesson: [lessons_board: [classrooms_grade: :classroom]])
+      .joins(:teacher_discipline_classroom)
+      .joins('INNER JOIN disciplines d ON d.id = teacher_discipline_classrooms.discipline_id')
+      .where(classrooms: { id: classroom_id })
+      .where(lessons_boards: { period: periods })
+      .where('d.id IN (?)', discipline_ids)
+      .where(teacher_discipline_classrooms: { active: true })
+      .where(teacher_discipline_classrooms: { discarded_at: nil })
+      .where.not(weekday: nil)
+      .where.not(teacher_discipline_classroom_id: nil)
+      .distinct
+      .pluck('d.id', :weekday)
+    
+    weekdays_data.each do |discipline_id, weekday|
+      result[discipline_id] ||= []
+      result[discipline_id] << weekday unless result[discipline_id].include?(weekday)
+    end
+    
+    # Para disciplinas que não foram encontradas, tenta sem filtrar por período
+    missing_discipline_ids = discipline_ids - result.keys
+    if missing_discipline_ids.any?
+      weekdays_data_fallback = LessonsBoardLessonWeekday
+        .joins(lessons_board_lesson: [lessons_board: [classrooms_grade: :classroom]])
+        .joins(:teacher_discipline_classroom)
+        .joins('INNER JOIN disciplines d ON d.id = teacher_discipline_classrooms.discipline_id')
+        .where(classrooms: { id: classroom_id })
+        .where('d.id IN (?)', missing_discipline_ids)
+        .where(teacher_discipline_classrooms: { active: true })
+        .where(teacher_discipline_classrooms: { discarded_at: nil })
+        .where.not(weekday: nil)
+        .where.not(teacher_discipline_classroom_id: nil)
+        .distinct
+        .pluck('d.id', :weekday)
+      
+      weekdays_data_fallback.each do |discipline_id, weekday|
+        result[discipline_id] ||= []
+        result[discipline_id] << weekday unless result[discipline_id].include?(weekday)
+      end
+    end
+    
+    result
+  end
+
+  def get_discipline_weekdays(classroom_id, discipline_id, period)
+    # Método mantido para compatibilidade, mas agora usa o método otimizado
+    all_weekdays = get_all_disciplines_weekdays(classroom_id, [discipline_id], [period])
+    all_weekdays[discipline_id] || []
+  end
+end
+

--- a/app/views/dashboard/_teacher_dashboard.html.erb
+++ b/app/views/dashboard/_teacher_dashboard.html.erb
@@ -2,16 +2,6 @@
 
 <div class="row">
   <div class="col col-sm-12">
-    <%= render 'teacher_next_avaliations' %>
-  </div>
-</div>
-<div class="row">
-  <div class="col col-sm-12">
-    <%= render 'teacher_pending_avaliations' %>
-  </div>
-</div>
-<div class="row">
-  <div class="col col-sm-12">
-    <%= render 'teacher_work_done' %>
+    <%= render 'teacher_pending_records' %>
   </div>
 </div>

--- a/app/views/dashboard/_teacher_pending_records.html.erb
+++ b/app/views/dashboard/_teacher_pending_records.html.erb
@@ -1,0 +1,12 @@
+<% content_for :js do %>
+  <%= javascript_include_tag 'views/dashboard/teacher_pending_records' %>
+<% end %>
+
+<legend>Datas Pendentes</legend>
+
+<div id="teacher-pending-records-container">
+  <div class="text-center">
+    <i class="fa fa-spinner fa-spin"></i> Carregando...
+  </div>
+</div>
+

--- a/app/views/pending_records_report/form.html.erb
+++ b/app/views/pending_records_report/form.html.erb
@@ -1,0 +1,93 @@
+<div class="widget-body no-padding">
+  <%= simple_form_for @pending_records_report_form, url: pending_records_report_path, method: :post, html: { class: 'smart-form' } do |f| %>
+    <%= f.error_notification %>
+
+    <fieldset>
+      <div class="row">
+        <div class="col col-sm-4">
+          <%= f.input :unity_id, as: :select2, elements: @unities, user: current_user, readonly: !current_user.admin? %>
+        </div>
+
+        <div class="col col-sm-4">
+          <%= f.input :classroom_id, as: :select2, elements: @classrooms, user: current_user,
+                input_html: { value: @pending_records_report_form.classroom_id } %>
+        </div>
+
+        <div class="col col-sm-4">
+          <%= f.input :teacher_id, as: :select2, elements: @teachers, user: current_user,
+                input_html: { value: @pending_records_report_form.teacher_id } %>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col col-sm-4">
+          <%= f.input :discipline_id, as: :select2, elements: @disciplines, user: current_user,
+                input_html: { value: @pending_records_report_form.discipline_id } %>
+        </div>
+
+        <div class="col col-sm-4">
+          <%= f.input :start_at, as: :date %>
+        </div>
+
+        <div class="col col-sm-4">
+          <%= f.input :end_at, as: :date %>
+        </div>
+      </div>
+
+      <div class="row">
+        <%= f.input :school_calendar_year, as: :hidden %>
+      </div>
+    </fieldset>
+
+    <footer>
+      <div class="pull-right">
+        <%= f.submit 'Gerar Relatório', class: 'btn btn-primary pull-right', id: 'send-form' %>
+      </div>
+    </footer>
+  <% end %>
+</div>
+
+<% content_for :js do %>
+  <script>
+    $(document).ready(function() {
+      var $unity = $('#pending_records_report_form_unity_id');
+      var $classroom = $('#pending_records_report_form_classroom_id');
+      var $teacher = $('#pending_records_report_form_teacher_id');
+      var $discipline = $('#pending_records_report_form_discipline_id');
+
+      $classroom.on('change', function() {
+        var classroomId = $(this).val();
+        
+        if (classroomId) {
+          // Carregar professores da turma
+          $.ajax({
+            url: '<%= pending_records_report_classroom_teachers_path %>',
+            data: { classroom_id: classroomId },
+            success: function(data) {
+              var teachers = data.teachers.map(function(teacher) {
+                return { id: teacher.id, name: teacher.name, text: teacher.name };
+              });
+              $teacher.select2({ data: teachers, allowClear: true });
+            }
+          });
+
+          // Carregar disciplinas da turma
+          $.ajax({
+            url: '<%= pending_records_report_classroom_disciplines_path %>',
+            data: { classroom_id: classroomId },
+            success: function(data) {
+              var disciplines = data.disciplines.map(function(discipline) {
+                return { id: discipline.id, name: discipline.description, text: discipline.description };
+              });
+              $discipline.select2({ data: disciplines, allowClear: true });
+            }
+          });
+        } else {
+          $teacher.select2({ data: [], allowClear: true });
+          $discipline.select2({ data: [], allowClear: true });
+        }
+      });
+    });
+  </script>
+<% end %>
+

--- a/app/views/pending_records_report/report.html.erb
+++ b/app/views/pending_records_report/report.html.erb
@@ -1,0 +1,77 @@
+<div class="widget-body no-padding">
+  <div class="table-responsive">
+    <table class="table table-bordered table-striped table-condensed table-hover">
+      <thead>
+        <tr>
+          <th>Professor</th>
+          <th>Disciplina</th>
+          <th>Turma</th>
+          <th>Período</th>
+          <th>Dias Letivos</th>
+          <th>Frequências Registradas</th>
+          <th>Conteúdos Registrados</th>
+          <th>Pendências Frequência</th>
+          <th>Pendências Conteúdo</th>
+          <th>Datas Pendentes Frequência</th>
+          <th>Datas Pendentes Conteúdo</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% if @results.present? %>
+          <% @results.each do |result| %>
+            <tr>
+              <td><%= result[:teacher_name] %></td>
+              <td><%= result[:discipline_name] %></td>
+              <td><%= result[:classroom_name] %></td>
+              <td><%= result[:period] %></td>
+              <td><%= result[:total_school_days] %></td>
+              <td><%= result[:total_frequencies] %></td>
+              <td><%= result[:total_content_records] %></td>
+              <td>
+                <span class="badge <%= result[:pending_frequency_count] > 0 ? 'badge-danger' : 'badge-success' %>">
+                  <%= result[:pending_frequency_count] %>
+                </span>
+              </td>
+              <td>
+                <span class="badge <%= result[:pending_content_count] > 0 ? 'badge-danger' : 'badge-success' %>">
+                  <%= result[:pending_content_count] %>
+                </span>
+              </td>
+              <td>
+                <% if result[:pending_frequency_dates].present? %>
+                  <small>
+                    <%= result[:pending_frequency_dates].map { |d| d.strftime('%d/%m/%Y') }.join(', ') %>
+                  </small>
+                <% else %>
+                  <span class="text-success">Nenhuma</span>
+                <% end %>
+              </td>
+              <td>
+                <% if result[:pending_content_dates].present? %>
+                  <small>
+                    <%= result[:pending_content_dates].map { |d| d.strftime('%d/%m/%Y') }.join(', ') %>
+                  </small>
+                <% else %>
+                  <span class="text-success">Nenhuma</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <td colspan="11" class="text-center">
+              <p class="text-muted">Nenhum resultado encontrado para os filtros selecionados.</p>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="widget-footer">
+    <div class="pull-left">
+      <%= link_to 'Voltar', pending_records_report_path, class: 'btn btn-default' %>
+    </div>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
       resources :teacher_next_avaliations, only: [:index]
       resources :teacher_pending_avaliations, only: [:index]
       resources :teacher_work_done_chart, only: [:index]
+      resources :teacher_pending_records, only: [:index]
     end
 
     post '/current_role', to: 'current_role#set', as: :set_current_role
@@ -410,6 +411,11 @@ Rails.application.routes.draw do
     get '/reports/attendance_record_report_by_students/report',
       to: 'attendance_record_report_by_students#report',
       as: 'attendance_record_report_by_students_report'
+
+    get '/reports/pending_records', to: 'pending_records_report#form', as: 'pending_records_report'
+    post '/reports/pending_records', to: 'pending_records_report#report', as: 'pending_records_report'
+    get '/reports/pending_records/classroom_teachers', to: 'pending_records_report#classroom_teachers', as: 'pending_records_report_classroom_teachers'
+    get '/reports/pending_records/classroom_disciplines', to: 'pending_records_report#classroom_disciplines', as: 'pending_records_report_classroom_disciplines'
 
     get '/reports/absence_justification', to: 'absence_justification_report#form', as: 'absence_justification_report'
     post '/reports/absence_justification', to: 'absence_justification_report#report', as: 'absence_justification_report'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,11 @@ Rails.application.routes.draw do
       resources :teacher_next_avaliations, only: [:index]
       resources :teacher_pending_avaliations, only: [:index]
       resources :teacher_work_done_chart, only: [:index]
-      resources :teacher_pending_records, only: [:index]
+      resources :teacher_pending_records, only: [:index] do
+        collection do
+          get :dates
+        end
+      end
     end
 
     post '/current_role', to: 'current_role#set', as: :set_current_role


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a teacher “pending records” dashboard widget with drill-down dates, a Pending Records report (form + results), supporting controllers/routes, and a batch-optimized calculator service.
> 
> - **Dashboard (Teacher)**
>   - Adds `teacher_pending_records` widget (`_teacher_pending_records.html.erb`, `teacher_pending_records.js`) with step selector, per-discipline/knowledge-area pending counts, and on-demand AJAX date details.
>   - Replaces previous teacher dashboard widgets with `render 'teacher_pending_records'` in `dashboard/_teacher_dashboard.html.erb`.
> - **Backend APIs**
>   - New `Dashboard::TeacherPendingRecordsController` with `index` (steps + per-step pending counts) and `dates` (pending dates for frequency/content) JSON endpoints.
>   - Routes: `dashboard/teacher_pending_records#index` and `#dates`.
> - **Reporting**
>   - New `PendingRecordsReportController` with `form`, `report` (HTML/JSON), and helper endpoints `classroom_teachers` and `classroom_disciplines`.
>   - Views: `reports/pending_records` form (filters: unity, classroom, teacher, discipline, date range, year) and tabular report with pending counts and dates.
>   - Form object `PendingRecordsReportForm` with validations.
>   - Routes for `/reports/pending_records` and related AJAX collections.
> - **Service**
>   - Adds `PendingRecordsCalculator` service: computes pending frequency/content per teacher/discipline (or knowledge area for infantil), supports `count_only`, batches queries, and respects frequency type and school calendar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e880e7d65e1aeabeb0778476c22484c5228d24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->