### PR TITLE
Hotfix/media transferidos

### DIFF
--- a/app/helpers/daily_frequency_helper.rb
+++ b/app/helpers/daily_frequency_helper.rb
@@ -32,11 +32,17 @@ module DailyFrequencyHelper
   end
 
   def get_start_at(daily_frequency)
-    StepsFetcher.new(daily_frequency.classroom).step_by_date(daily_frequency.frequency_date).start_at
+    step = StepsFetcher.new(daily_frequency.classroom).step_by_date(daily_frequency.frequency_date)
+    # Se não há step (data fora dos períodos letivos mas com evento que permite lançamentos),
+    # usa a própria data da frequência como fallback
+    step&.start_at || daily_frequency.frequency_date
   end
 
   def get_end_at(daily_frequency)
-    StepsFetcher.new(daily_frequency.classroom).step_by_date(daily_frequency.frequency_date).end_at
+    step = StepsFetcher.new(daily_frequency.classroom).step_by_date(daily_frequency.frequency_date)
+    # Se não há step (data fora dos períodos letivos mas com evento que permite lançamentos),
+    # usa a própria data da frequência como fallback
+    step&.end_at || daily_frequency.frequency_date
   end
 
   def frequency_student_name_class(dependence, active, exempted_from_discipline, in_active_search)

--- a/app/models/daily_frequency.rb
+++ b/app/models/daily_frequency.rb
@@ -170,6 +170,12 @@ class DailyFrequency < ApplicationRecord
   def ensure_belongs_to_step
     return if school_calendar.blank? || frequency_date.blank?
 
+    # Se há um evento que permite lançamentos, não precisa verificar step
+    # (eventos "não letivo - permite lançamentos" podem estar fora dos períodos letivos)
+    if school_calendar.day_allows_entry?(frequency_date, nil, classroom_id, discipline_id)
+      return
+    end
+
     step = StepsFetcher.new(classroom).step_by_date(frequency_date)
     errors.add(:frequency_date, I18n.t('errors.messages.is_not_between_steps')) if step.blank?
   end

--- a/app/models/discipline_content_record.rb
+++ b/app/models/discipline_content_record.rb
@@ -144,7 +144,9 @@ class DisciplineContentRecord < ActiveRecord::Base
                   record_date.present?
 
     grades.each do |grade|
-      unless content_record.school_calendar.school_day?(record_date, grade, classroom_id, discipline)
+      # Usa day_allows_entry? em vez de school_day? para permitir lançamentos
+      # mesmo em dias não letivos se houver evento que permite lançamentos
+      unless content_record.school_calendar.day_allows_entry?(record_date, grade, classroom_id, discipline_id)
         errors.add(:base, :not_school_calendar_day)
         content_record.errors.add(:record_date, :not_school_calendar_day)
       end

--- a/app/models/knowledge_area_content_record.rb
+++ b/app/models/knowledge_area_content_record.rb
@@ -117,7 +117,9 @@ class KnowledgeAreaContentRecord < ActiveRecord::Base
                   content_record.school_calendar.present? &&
                   record_date.present?
 
-    unless content_record.school_calendar.school_day?(record_date, grades.first, classroom_id)
+    # Usa day_allows_entry? em vez de school_day? para permitir lançamentos
+    # mesmo em dias não letivos se houver evento que permite lançamentos
+    unless content_record.school_calendar.day_allows_entry?(record_date, grades.first, classroom_id, nil)
       errors.add(:base, "")
       content_record.errors.add(:record_date, :not_school_calendar_day)
     end

--- a/app/reports/exam_record_all_steps_averages_adaptive_report.rb
+++ b/app/reports/exam_record_all_steps_averages_adaptive_report.rb
@@ -114,7 +114,12 @@ class ExamRecordAllStepsAveragesAdaptiveReport < BaseReport
       step_averages_with_recovery = []
       
       @steps.each_with_index do |step, step_index|
+        # Calcular média localmente primeiro
         average = StudentAverageCalculator.new(student).calculate(@classroom, @discipline, step)
+        # Se a média estiver null ou em branco, buscar no i-educar
+        if average.blank?
+          average = fetch_average_from_ieducar(student_id, step.step_number)
+        end
         step_averages[student_enrollment.id] << average
         
         # Buscar recuperação por etapa
@@ -241,6 +246,25 @@ class ExamRecordAllStepsAveragesAdaptiveReport < BaseReport
     return score if score == 'D' || score == 'N'
 
     number_with_precision(score, precision: 1, separator: ',', delimiter: '.')
+  end
+
+  def fetch_average_from_ieducar(student_id, step_number)
+    ieducar_api_configuration = IeducarApiConfiguration.current
+    return nil if ieducar_api_configuration.blank?
+
+    fetcher = StudentAverageFromIeducarFetcher.new(ieducar_api_configuration)
+    average = fetcher.fetch(student_id, @classroom.id, @discipline.id, step_number)
+    
+    # Arredondar a média conforme as configurações da turma
+    if average.present?
+      step = @steps.find { |s| s.step_number == step_number }
+      ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, step).round(average) if step
+    else
+      nil
+    end
+  rescue StandardError => error
+    Rails.logger.error "Erro ao buscar média do i-educar: #{error.message}"
+    nil
   end
 end
 

--- a/app/reports/exam_record_all_steps_averages_report.rb
+++ b/app/reports/exam_record_all_steps_averages_report.rb
@@ -116,7 +116,12 @@ class ExamRecordAllStepsAveragesReport < BaseReport
       # Calcular médias de cada etapa
       step_averages[student_enrollment.id] = []
       @steps.each do |step|
+        # Calcular média localmente primeiro
         average = StudentAverageCalculator.new(student).calculate(@classroom, @discipline, step)
+        # Se a média estiver null ou em branco, buscar no i-educar
+        if average.blank?
+          average = fetch_average_from_ieducar(student_id, step.step_number)
+        end
         step_averages[student_enrollment.id] << average
       end
 
@@ -314,6 +319,25 @@ class ExamRecordAllStepsAveragesReport < BaseReport
     return score if score == 'D' || score == 'N'
 
     number_with_precision(score, precision: 1, separator: ',', delimiter: '.')
+  end
+
+  def fetch_average_from_ieducar(student_id, step_number)
+    ieducar_api_configuration = IeducarApiConfiguration.current
+    return nil if ieducar_api_configuration.blank?
+
+    fetcher = StudentAverageFromIeducarFetcher.new(ieducar_api_configuration)
+    average = fetcher.fetch(student_id, @classroom.id, @discipline.id, step_number)
+    
+    # Arredondar a média conforme as configurações da turma
+    if average.present?
+      step = @steps.find { |s| s.step_number == step_number }
+      ScoreRounder.new(@classroom, RoundedAvaliations::NUMERICAL_EXAM, step).round(average) if step
+    else
+      nil
+    end
+  rescue StandardError => error
+    Rails.logger.error "Erro ao buscar média do i-educar: #{error.message}"
+    nil
   end
 end
 

--- a/app/services/ieducar_api/student_averages.rb
+++ b/app/services/ieducar_api/student_averages.rb
@@ -1,17 +1,62 @@
 module IeducarApi
   class StudentAverages < Base
     def fetch(params = {})
-      params.reverse_merge!(
-        path: 'module/Api/Boletim',
-        resource: 'media-geral'
-      )
+      # Parâmetros esperados pela nova API
+      registration_id = params[:registration_id]
+      discipline_id = params[:discipline_id]
+      stage = params[:stage]
 
-      raise ApiError, 'É necessário informar o código do aluno' if params[:aluno_id].blank?
-      raise ApiError, 'É necessário informar o código da turma' if params[:turma_id].blank?
-      raise ApiError, 'É necessário informar o código do componente curricular' if params[:componente_curricular_id].blank?
-      raise ApiError, 'É necessário informar o código da etapa' if params[:etapa].blank?
+      raise ApiError, 'É necessário informar o registration_id' if registration_id.blank?
+      raise ApiError, 'É necessário informar o discipline_id' if discipline_id.blank?
+      raise ApiError, 'É necessário informar o stage (etapa)' if stage.blank?
 
-      super
+      endpoint = "#{url}/api/student-score"
+      query_params = {
+        access_key: access_key,
+        secret_key: secret_key,
+        registration_id: registration_id,
+        discipline_id: discipline_id,
+        stage: stage
+      }
+
+      request_url = "#{endpoint}?#{query_params.to_query}"
+      
+      Rails.logger.info "GET #{request_url}"
+      Sidekiq.logger.info "GET #{request_url}"
+      
+      begin
+        response = RestClient::Request.execute(
+          method: :get,
+          url: request_url,
+          read_timeout: 240,
+          open_timeout: 30
+        )
+
+        JSON.parse(response)
+      rescue SocketError, RestClient::ExceptionWithResponse => error
+        if RETRY_NETWORK_ERRORS.any? { |network_error| error.message.include?(network_error) }
+          raise NetworkException, error.message
+        end
+
+        http_code = error.respond_to?(:http_code) ? error.http_code : 'N/A'
+        error_class_name = error.class.name.split('::').last
+
+        Rails.logger.error "Erro ao acessar API i-Educar - URL: #{url}, Endpoint: #{endpoint}, URL Completa: #{request_url}, Erro: #{error_class_name}, HTTP: #{http_code}, Mensagem: #{error.message}"
+
+        if http_code == 401
+          error_message = "Autenticação falhou (HTTP 401). Verifique se access_key e secret_key estão corretos."
+        elsif http_code == 404
+          error_message = "Endpoint não encontrado na API do i-Educar. Endpoint: #{endpoint}. Verifique se o recurso está disponível nesta versão da API."
+        else
+          error_message = "Erro ao acessar API do i-Educar. URL: #{url}, Erro: #{error_class_name}"
+          error_message += " (HTTP #{http_code})" if http_code != 'N/A'
+          error_message += " - #{error.message}" if error.message.present?
+        end
+        raise ApiError, error_message
+      rescue StandardError => error
+        Rails.logger.error "Erro inesperado ao buscar média do i-educar: #{error.message}"
+        raise ApiError, error.message
+      end
     end
   end
 end

--- a/app/services/student_average_from_ieducar_fetcher.rb
+++ b/app/services/student_average_from_ieducar_fetcher.rb
@@ -19,6 +19,8 @@ class StudentAverageFromIeducarFetcher
       etapa: step_number
     )
 
+    logger.info "Result: #{result.inspect}"
+
     # A API pode retornar a média em diferentes formatos
     # Tentar diferentes chaves possíveis
     media = result['media'] || result['nota'] || result['media_geral']
@@ -33,10 +35,12 @@ class StudentAverageFromIeducarFetcher
       nil
     end
   rescue IeducarApi::Base::ApiError => error
-    Rails.logger.error "Erro ao buscar média do i-educar: #{error.message}"
+    logger.error "Erro ao buscar média do i-educar: #{error.message}"
+    logger.error "Backtrace: #{error.backtrace.join("\n")}" if error.backtrace
     nil
   rescue StandardError => error
-    Rails.logger.error "Erro inesperado ao buscar média do i-educar: #{error.message}"
+    logger.error "Erro inesperado ao buscar média do i-educar: #{error.message}"
+    logger.error "Backtrace: #{error.backtrace.join("\n")}" if error.backtrace
     nil
   end
 
@@ -44,6 +48,18 @@ class StudentAverageFromIeducarFetcher
 
   def api
     IeducarApi::StudentAverages.new(@ieducar_api_configuration.to_api)
+  end
+
+  def logger
+    @logger ||= begin
+      log_file = Rails.root.join('log', 'student_average_from_ieducar.log')
+      logger = Logger.new(log_file, 'daily')
+      logger.level = Logger::INFO
+      logger.formatter = proc do |severity, datetime, progname, msg|
+        "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{severity} -- #{msg}\n"
+      end
+      logger
+    end
   end
 end
 

--- a/app/services/student_average_from_ieducar_fetcher.rb
+++ b/app/services/student_average_from_ieducar_fetcher.rb
@@ -12,28 +12,43 @@ class StudentAverageFromIeducarFetcher
 
     return nil if student.api_code.blank? || classroom.api_code.blank? || discipline.api_code.blank?
 
+    # Buscar a matrícula (StudentEnrollment) do aluno na turma
+    student_enrollment = StudentEnrollment
+      .by_student(student_id)
+      .by_classroom(classroom_id)
+      .first
+
+    return nil if student_enrollment.blank? || student_enrollment.api_code.blank?
+
     result = api.fetch(
-      aluno_id: student.api_code,
-      turma_id: classroom.api_code,
-      componente_curricular_id: discipline.api_code,
-      etapa: step_number
+      registration_id: student_enrollment.api_code,
+      discipline_id: discipline.api_code,
+      stage: step_number
     )
 
     logger.info "Result: #{result.inspect}"
 
-    # A API pode retornar a média em diferentes formatos
-    # Tentar diferentes chaves possíveis
-    media = result['media'] || result['nota'] || result['media_geral']
-    
-    if media.present?
-      media.to_f
-    elsif result.is_a?(Array) && result.first.present?
-      # Se retornar um array, pegar o primeiro elemento
-      media_from_array = result.first['media'] || result.first['nota'] || result.first['media_geral']
-      media_from_array.present? ? media_from_array.to_f : nil
-    else
-      nil
-    end
+    # A API retorna: {"message"=>"...", "data"=>{"stage"=>1, "score"=>"7.5", ...}}
+    # ou {"message"=>"...", "data"=>[{"stage"=>1, "score"=>"7.5", ...}]} (array)
+    return nil unless result.is_a?(Hash) && result['data'].present?
+
+    # Se data for um array, busca a etapa específica (compatibilidade com versões antigas)
+    stage_data = if result['data'].is_a?(Array)
+                   result['data'].find { |item| item['stage'] == step_number }
+                 else
+                   result['data']
+                 end
+
+    return nil unless stage_data.present?
+
+    # Prioridade: recovery_specific_score > recovery_parallel_score > score
+    score = stage_data['recovery_specific_score'] || 
+            stage_data['recovery_parallel_score'] || 
+            stage_data['score']
+
+    return nil if score.blank?
+
+    score.to_f
   rescue IeducarApi::Base::ApiError => error
     logger.error "Erro ao buscar média do i-educar: #{error.message}"
     logger.error "Backtrace: #{error.backtrace.join("\n")}" if error.backtrace

--- a/script/auto_update.sh
+++ b/script/auto_update.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-TOTAL_RAM_GB=$(free -g | awk '/^Mem:/{print $2}')
-
 TZ="America/Sao_Paulo"
 export TZ
 
@@ -74,11 +72,11 @@ if is_dawn; then
   if [[ "${CIDADE_COD:-}" == *delmiro* ]]; then
     echo "Sincronizando Delmiro..."
     
-    sudo systemctl stop rails-server.service
+    sudo systemctl stop puma.service
     RAILS_ENV=production bundle exec rake ieducar_api:synchronize[true,true]
   
     sleep 30m
-    sudo systemctl restart rails-server.service
+    sudo systemctl start puma.service
   
   else
     RAILS_ENV=production bundle exec rake ieducar_api:synchronize[true,true]
@@ -100,22 +98,6 @@ GIT_OUTPUT=$(git pull)
 # Verifica se houve alterações
 if echo "$GIT_OUTPUT" | grep -q "Already up to date\|Atualizado"; then
   echo "Nenhuma alteração detectada. Preparando para encerrar script."
-
-  echo "Verificando envio de avaliações..."
-  PIDS=$(pgrep -f post_avaliations || true)
-  if [ -n "$PIDS" ]; then 
-    echo "===> O envio automático de avaliações já está rodando (PIDs: $PIDS)"
-  else
-    echo "===> INICIANDO o envio automático de avaliações"
-    
-    nohup bundle exec rake post_avaliations:init ORDER=asc RAILS_ENV=production > log/auto_post.log 2>&1 &
-    echo $! > tmp/auto_post.pid
-
-    if [ "$TOTAL_RAM_GB" -gt 10 ]; then
-      nohup bundle exec rake post_avaliations:init ORDER=desc RAILS_ENV=production > log/auto_post_desc.log 2>&1 &
-      echo $! > tmp/auto_post_desc.pid
-    fi
-  fi 
 
   exit 0 #encerra script
 fi
@@ -201,13 +183,11 @@ else
 fi
 
 echo "===> INICIANDO SERVIÇO de envio automático de avaliações"
-nohup bundle exec rake post_avaliations:init ORDER=asc RAILS_ENV=production > log/auto_post.log 2>&1 &
-echo $! > tmp/auto_post.pid
+systemctl restart auto_post_asc.service
 
-# Verifica se o sistema tem mais de 8GB de RAM antes de iniciar o processo DESC
-if [ "$TOTAL_RAM_GB" -gt 10 ]; then
-  nohup bundle exec rake post_avaliations:init ORDER=desc RAILS_ENV=production > log/auto_post_desc.log 2>&1 &
-  echo $! > tmp/auto_post_desc.pid
+# Verifica se o serviço está em execução antes de reiniciar o processo DESC
+if systemctl is-active --quiet auto_post_desc.service; then
+  systemctl restart auto_post_desc.service
 fi
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Highlights
> 
> - **Calendar/validation**: `DailyFrequency` skips step validation when `school_calendar.day_allows_entry?` is true; `DisciplineContentRecord` and `KnowledgeAreaContentRecord` now validate with `day_allows_entry?` instead of `school_day?`.
> - **Printing helpers**: `DailyFrequencyHelper` `get_start_at`/`get_end_at` now fallback to the frequency date when no `step` is found.
> - **Reports**: In both `exam_record_all_steps_averages_*_report.rb`, step averages now fallback to fetching from i‑Educar when local calculation is blank, then rounded per classroom config; added `fetch_average_from_ieducar` helper.
> - **i‑Educar integration**: New/rewritten client `IeducarApi::StudentAverages` targeting `/api/student-score` with `registration_id`, `discipline_id`, `stage`, plus improved logging/error handling. `StudentAverageFromIeducarFetcher` updated to use enrollment (`registration_id`), parse new response (`data` with `score`/recovery fields), and dedicated logger.
> - **Ops script**: `script/auto_update.sh` switches to puma service control, removes RAM‑based forks, and restarts `auto_post_*` via systemd services.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 133f86ee230c1f829b667af45888aca90c634ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->