### PR TITLE
avaliação conceitual em lote

### DIFF
--- a/app/assets/javascripts/views/conceptual_exams/form_batch.js
+++ b/app/assets/javascripts/views/conceptual_exams/form_batch.js
@@ -1,0 +1,11 @@
+$(function () {
+  'use strict';
+
+  if ($('.concept-select').length && typeof $.fn.select2 !== 'undefined') {
+    $('.concept-select').select2({
+      width: '100%',
+      allowClear: true,
+      placeholder: ''
+    });
+  }
+});

--- a/app/assets/javascripts/views/conceptual_exams/new_batch.js
+++ b/app/assets/javascripts/views/conceptual_exams/new_batch.js
@@ -1,0 +1,39 @@
+$(function () {
+  'use strict';
+
+  var $classroom = $('#conceptual_exam_batch_classroom_id');
+  var $step = $('#conceptual_exam_batch_step_id');
+  var flashMessages = new FlashMessages();
+
+  $classroom.on('change', function () {
+    getStep();
+  });
+
+  function getStep() {
+    var classroom_id = $classroom.select2('val');
+    if (!_.isEmpty(classroom_id)) {
+      $.ajax({
+        url: Routes.find_step_number_by_classroom_conceptual_exams_pt_br_path({
+          classroom_id: classroom_id,
+          format: 'json'
+        }),
+        success: handleFetchStepByClassroomSuccess,
+        error: handleFetchStepByClassroomError
+      });
+    }
+  }
+
+  function handleFetchStepByClassroomSuccess(data) {
+    var selectedSteps = data.map(function (step) {
+      return { id: step.id, text: step.description, start_at: step.start_at, end_at: step.end_at };
+    });
+    $step.select2({ data: selectedSteps });
+    if (selectedSteps.length > 0) {
+      $step.val(selectedSteps[0].id).trigger('change');
+    }
+  }
+
+  function handleFetchStepByClassroomError() {
+    flashMessages.error('Ocorreu um erro ao buscar a etapa da turma.');
+  }
+});

--- a/app/controllers/conceptual_exams_controller.rb
+++ b/app/controllers/conceptual_exams_controller.rb
@@ -5,8 +5,9 @@ class ConceptualExamsController < ApplicationController
   before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
-  before_action :allow_teacher_modify_prev_years, only: [:create, :update]
+  before_action :allow_teacher_modify_prev_years, only: [:create, :update, :create_batch]
   before_action :view_data, only: [:edit, :show]
+  before_action :require_batch_layout_enabled, only: [:new_batch, :form_batch, :create_batch]
 
   def index
     step_id = (params[:filter] || []).delete(:by_step)
@@ -14,12 +15,18 @@ class ConceptualExamsController < ApplicationController
 
     set_options_by_user
 
-    @conceptual_exams = fetch_conceptual_exams
-    @only_one_conceptual_avaliation = Rails.application.secrets.only_one_conceptual_avaliation.present? && Rails.application.secrets.only_one_conceptual_avaliation
+    @conceptual_exam_batch_layout = conceptual_exam_batch_layout?
 
-    check_status_and_step(step_id, status)
-
-    authorize @conceptual_exams
+    if @conceptual_exam_batch_layout
+      @classroom = current_user_classroom
+      @steps = steps_fetcher(@classroom).steps if @classroom.present?
+      authorize ConceptualExam.new(classroom_id: @classroom&.id, student_id: nil)
+    else
+      @conceptual_exams = fetch_conceptual_exams
+      @only_one_conceptual_avaliation = Rails.application.secrets.only_one_conceptual_avaliation.present? && Rails.application.secrets.only_one_conceptual_avaliation
+      check_status_and_step(step_id, status)
+      authorize @conceptual_exams
+    end
   end
 
   def new
@@ -186,6 +193,130 @@ class ConceptualExamsController < ApplicationController
     steps = step_numbers.map { |step| { id: step.id, description: step.to_s, start_at: step.start_at, end_at: step.end_at } }
 
     render json: steps.to_json
+  end
+
+  def new_batch
+    set_options_by_user
+    @batch_form = ConceptualExamBatchForm.new(
+      unity_id: current_unity.id,
+      classroom_id: current_user_classroom.id,
+      teacher_id: current_teacher_id,
+      current_user: current_user
+    )
+    authorize ConceptualExam.new(classroom_id: current_user_classroom.id, student_id: nil)
+  end
+
+  def form_batch
+    @batch_form = ConceptualExamBatchForm.new(batch_form_params)
+    @batch_form.teacher_id = current_teacher_id
+    @batch_form.current_user = current_user
+
+    unless @batch_form.valid?
+      set_options_by_user
+      flash.now[:alert] = @batch_form.errors.full_messages.join('; ')
+      return render :new_batch
+    end
+
+    @classroom = @batch_form.classroom
+    @step = @batch_form.step
+    @recorded_at = batch_last_date_of_step(@step)
+    @batch_form.recorded_at = @recorded_at
+
+    only_one = Rails.application.secrets.only_one_conceptual_avaliation.present? && Rails.application.secrets.only_one_conceptual_avaliation
+    if only_one
+      # Na configuração "uma etapa só", step e recorded_at vêm do primeiro aluno; aqui usamos step_id do form
+      @step = StepsFetcher.new(@classroom).step_by_id(@batch_form.step_id)
+    end
+
+    @student_enrollments = batch_student_enrollments(@classroom, @step)
+    student_ids = @student_enrollments.map(&:student_id).uniq
+    @students = Student.where(id: student_ids).ordered
+
+    @disciplines_by_student = batch_disciplines_by_student(@classroom, @students, @step)
+    @all_discipline_ids = @disciplines_by_student.values.flatten.uniq
+    @disciplines = Discipline.where(id: @all_discipline_ids).includes(:knowledge_area)
+    @disciplines = @disciplines.to_a.sort_by { |d| [d.knowledge_area&.sequence.to_i, d.knowledge_area&.description.to_s, d.sequence.to_i, d.description] }
+
+    @exempted_by_student = batch_exempted_by_student(@student_enrollments, @step)
+    @existing_by_student = batch_existing_conceptual_exams(@classroom, @step, student_ids)
+
+    authorize ConceptualExam.new(classroom_id: @classroom.id, student_id: @students.first&.id)
+    render :form_batch
+  end
+
+  def create_batch
+    set_options_by_user
+    @batch_form = ConceptualExamBatchForm.new(create_batch_params)
+    @batch_form.teacher_id = current_teacher_id
+    @batch_form.current_user = current_user
+
+    unless @batch_form.valid?
+      return redirect_to new_batch_conceptual_exams_path, alert: @batch_form.errors.full_messages.join('; ')
+    end
+
+    @classroom = @batch_form.classroom
+    @step = @batch_form.step
+    record_at = batch_valid_recorded_at(@step, @batch_form.recorded_at.to_date, @classroom)
+    record_at = batch_last_date_of_step(@step) if record_at.blank?
+
+    only_one = Rails.application.secrets.only_one_conceptual_avaliation.present? && Rails.application.secrets.only_one_conceptual_avaliation
+    saved = 0
+    errors = []
+
+    (@batch_form.students || {}).each do |student_id_str, disciplines_hash|
+      begin
+        student_id = student_id_str.to_i
+        next if student_id.zero?
+
+        values_by_discipline = (disciplines_hash || {}).reject { |_d, v| v.blank? }
+        next if values_by_discipline.empty?
+
+        if only_one
+          enrollment = StudentEnrollmentClassroom.by_classroom(@classroom.id).by_student(student_id).first
+          step = enrollment ? find_step_by_date(enrollment.joined_at) : @step
+          record_at = step && (enrollment.joined_at.to_date < step.start_at) ? step.start_at : (enrollment&.joined_at&.to_date || record_at)
+          record_at = batch_valid_recorded_at(step, record_at, @classroom) if step.present?
+        else
+          step = @step
+        end
+
+        # Se já existir lançamento para este aluno nesta etapa, editar o existente.
+        conceptual_exam = ConceptualExam.by_classroom(@classroom.id)
+                                        .by_student_id(student_id)
+                                        .by_step_number(step.step_number)
+                                        .first
+        conceptual_exam ||= ConceptualExam.new(
+          classroom_id: @classroom.id,
+          student_id: student_id,
+          recorded_at: record_at
+        )
+        conceptual_exam.unity_id = @classroom.unity_id
+        conceptual_exam.step_id = step.id
+        conceptual_exam.step_number = step.step_number
+        conceptual_exam.recorded_at = record_at
+        conceptual_exam.teacher_id = current_teacher_id
+        conceptual_exam.current_user = current_user
+
+        build_batch_conceptual_exam_values(conceptual_exam, values_by_discipline)
+        conceptual_exam.merge_conceptual_exam_values
+
+        authorize conceptual_exam
+        if conceptual_exam.save
+          saved += 1
+        else
+          errors << "#{Student.find_by(id: student_id)&.name}: #{conceptual_exam.errors.full_messages.join(', ')}"
+        end
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+    end
+
+    if errors.any?
+      flash[:alert] = "Salvos: #{saved}. Erros: #{errors.join('; ')}"
+    else
+      flash[:notice] = I18n.t('conceptual_exams.create_batch.saved', count: saved)
+    end
+    redirect_to conceptual_exams_path
   end
 
   def fetch_score_type
@@ -587,6 +718,136 @@ class ConceptualExamsController < ApplicationController
       year = current_school_year || current_school_calendar.year
       steps ||= SchoolCalendar.find_by(unity_id: current_unity.id, year: year).steps
       steps
+    end
+  end
+
+  def conceptual_exam_batch_layout?
+    Rails.application.secrets.conceptual_exam_batch_layout.present? &&
+      Rails.application.secrets.conceptual_exam_batch_layout
+  end
+
+  def require_batch_layout_enabled
+    return if conceptual_exam_batch_layout?
+
+    redirect_to conceptual_exams_path, alert: t('conceptual_exams.batch.not_available')
+  end
+
+  def batch_form_params
+    params.fetch(:conceptual_exam_batch, {}).permit(:unity_id, :classroom_id, :step_id)
+  end
+
+  def create_batch_params
+    p = params.require(:conceptual_exam_batch).permit(:unity_id, :classroom_id, :step_id, :recorded_at)
+    # Strong Parameters não permite hashes aninhados com chaves dinâmicas (student_id => { discipline_id => value }).
+    # Precisamos permitir o subtree students explicitamente.
+    if params[:conceptual_exam_batch][:students].present?
+      p[:students] = params[:conceptual_exam_batch][:students].permit!.to_h
+    end
+    p[:recorded_at] = p[:recorded_at].to_date if p[:recorded_at].present?
+    p
+  end
+
+  # Última data da etapa (último dia letivo quando disponível, senão end_at).
+  def batch_last_date_of_step(step)
+    return nil if step.blank?
+
+    if step.respond_to?(:school_day_dates) && step.school_day_dates.present?
+      step.school_day_dates.last
+    elsif step.respond_to?(:school_calendar_step_day?) && step.respond_to?(:start_at) && step.respond_to?(:end_at)
+      range = (step.start_at.to_date..step.end_at.to_date).to_a
+      range.reverse.find { |d| step.school_calendar_step_day?(d) } || step.end_at.to_date
+    else
+      step.end_at.to_date
+    end
+  end
+
+  def batch_student_enrollments(classroom, step)
+    period = TeacherPeriodFetcher.new(current_teacher.id, classroom.id, current_user_discipline).teacher_period
+    period = nil if period == Periods::FULL.to_i
+    StudentEnrollmentsList.new(
+      classroom: classroom,
+      discipline: current_user_discipline,
+      start_at: step.start_at,
+      end_at: step.end_at,
+      score_type: StudentEnrollmentScoreTypeFilters::CONCEPT,
+      search_type: :by_date_range,
+      period: period
+    ).student_enrollments
+  end
+
+  def batch_disciplines_by_student(classroom, students, step)
+    school_calendar = SchoolCalendar.find_by(unity_id: classroom.unity_id, year: classroom.year)
+    return {} if school_calendar.blank?
+
+    teacher_discipline_ids = TeacherDisciplineClassroom
+      .by_classroom(classroom.id)
+      .by_teacher_id(current_teacher_id)
+      .by_year(current_school_calendar.year)
+      .pluck(:discipline_id)
+      .uniq
+
+    step_number = step.respond_to?(:to_number) ? step.to_number : step.step_number
+    exempted_discipline_ids = ExemptedDisciplinesInStep.discipline_ids(classroom.id, step_number)
+    discipline_ids_global = Discipline
+      .where(id: teacher_discipline_ids)
+      .by_score_type(ScoreTypes::CONCEPT)
+      .not_grouper
+      .descriptor
+      .where.not(id: exempted_discipline_ids)
+      .pluck(:id)
+
+    result = {}
+    students.each do |student|
+      cg = ClassroomsGrade.by_student_id(student.id).by_classroom_id(classroom.id).first
+      next if cg.blank?
+
+      grade_discipline_ids = SchoolCalendarDisciplineGrade
+        .where(school_calendar_id: school_calendar.id, grade_id: cg.grade_id)
+        .pluck(:discipline_id)
+      result[student.id] = (discipline_ids_global & grade_discipline_ids)
+    end
+    result
+  end
+
+  def batch_exempted_by_student(student_enrollments, step)
+    result = {}
+    step_number = step.respond_to?(:to_number) ? step.to_number : step.step_number
+    student_enrollments.each do |enrollment|
+      exempted = enrollment.exempted_disciplines&.by_step_number(step_number)
+      result[enrollment.student_id] = exempted ? exempted.pluck(:discipline_id) : []
+    end
+    result
+  end
+
+  def batch_existing_conceptual_exams(classroom, step, student_ids)
+    ConceptualExam
+      .by_classroom(classroom.id)
+      .by_step_number(step.step_number)
+      .where(student_id: student_ids)
+      .includes(:conceptual_exam_values)
+      .index_by(&:student_id)
+  end
+
+  # Retorna uma data que seja dia letivo da etapa (para passar na validação do ConceptualExam).
+  def batch_valid_recorded_at(step, date, classroom)
+    return date if date.blank? || step.blank?
+
+    date = date.to_date
+    if step.respond_to?(:school_calendar_step_day?) && step.school_calendar_step_day?(date)
+      return date
+    end
+    step.respond_to?(:first_school_calendar_date) ? step.first_school_calendar_date : date
+  end
+
+  def build_batch_conceptual_exam_values(conceptual_exam, values_by_discipline)
+    conceptual_exam.conceptual_exam_values.destroy_all if conceptual_exam.persisted?
+    values_by_discipline.each do |discipline_id, value|
+      next if value.blank?
+
+      conceptual_exam.conceptual_exam_values.build(
+        discipline_id: discipline_id,
+        value: value
+      )
     end
   end
 end

--- a/app/forms/conceptual_exam_batch_form.rb
+++ b/app/forms/conceptual_exam_batch_form.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class ConceptualExamBatchForm
+  include ActiveModel::Model
+
+  attr_accessor :unity_id, :classroom_id, :step_id, :recorded_at, :students, :teacher_id, :current_user
+
+  validates :unity_id, presence: true
+  validates :classroom_id, presence: true
+  validates :step_id, presence: true
+  # recorded_at é definido internamente como última data da etapa (não é informado pelo usuário)
+
+  def initialize(attributes = {})
+    @students = attributes.delete(:students) || {}
+    @teacher_id = attributes.delete(:teacher_id)
+    @current_user = attributes.delete(:current_user)
+    super(attributes)
+  end
+
+  def students_attributes=(hash)
+    return if hash.blank?
+
+    @students = hash.to_unsafe_h if hash.respond_to?(:to_unsafe_h)
+    @students = hash.with_indifferent_access if hash.is_a?(Hash)
+  end
+
+  def classroom
+    @classroom ||= Classroom.find_by(id: classroom_id)
+  end
+
+  def step
+    return if step_id.blank? || classroom.blank?
+
+    @step ||= StepsFetcher.new(classroom).step_by_id(step_id)
+  end
+
+  def unity
+    @unity ||= Unity.find_by(id: unity_id)
+  end
+end

--- a/app/helpers/conceptual_exam_value_helper.rb
+++ b/app/helpers/conceptual_exam_value_helper.rb
@@ -1,4 +1,16 @@
 module ConceptualExamValueHelper
+  # Retorna opções para select de conceito (value) conforme regra do aluno na turma.
+  # Usado no layout em lote (form_batch) onde cada célula aluno x disciplina precisa do dropdown correto.
+  def concept_options_for_student(classroom, student)
+    return [] if classroom.blank? || student.blank?
+
+    exam_rule = ExamRuleFetcher.fetch(classroom, student)
+    rounding_table = exam_rule&.conceptual_rounding_table
+    return [] if rounding_table.blank?
+
+    rounding_table.rounding_table_values.map { |rtv| [rtv.to_s, rtv.value] }
+  end
+
   def conceptual_exam_value_student_name_class(conceptual_exam_value)
     if conceptual_exam_value.exempted_discipline.to_s == 'true'
       'exempted-student-from-discipline'

--- a/app/policies/conceptual_exam_policy.rb
+++ b/app/policies/conceptual_exam_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ConceptualExamPolicy < ApplicationPolicy
+  def new_batch?
+    create?
+  end
+
+  def form_batch?
+    create?
+  end
+
+  def create_batch?
+    create?
+  end
+end

--- a/app/views/conceptual_exams/_index_batch_layout.html.erb
+++ b/app/views/conceptual_exams/_index_batch_layout.html.erb
@@ -1,0 +1,41 @@
+<div class="conceptual-exams-batch-index">
+  <div class="well well-sm">
+    <h4><%= t('conceptual_exams.index.batch_layout_title') %></h4>
+    <p class="text-muted"><%= t('conceptual_exams.index.batch_layout_subtitle') %></p>
+    <% if @classroom.present? %>
+      <p>
+        <strong><%= t('conceptual_exams.index.batch_layout_classroom') %>:</strong> <%= @classroom.description %>
+      </p>
+    <% end %>
+  </div>
+
+  <% if @steps.present? %>
+    <div class="list-group">
+      <% @steps.each do |step| %>
+        <div class="list-group-item">
+          <div class="row">
+            <div class="col-sm-8 col-md-9">
+              <h5 class="list-group-item-heading"><%= step.to_s %></h5>
+              <p class="list-group-item-text text-muted small">
+                <%= l(step.start_at) %> a <%= l(step.end_at) %>
+              </p>
+            </div>
+            <div class="col-sm-4 col-md-3 text-right">
+              <%= link_to form_batch_conceptual_exams_path(conceptual_exam_batch: {
+                    unity_id: @classroom.unity_id,
+                    classroom_id: @classroom.id,
+                    step_id: step.id
+                  }), class: 'btn btn-primary' do %>
+                <i class='fa fa-edit'></i> <%= t('conceptual_exams.index.batch_layout_fill_button') %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      <i class="fa fa-info-circle"></i> <%= t('conceptual_exams.index.batch_layout_no_steps') %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/conceptual_exams/form_batch.html.erb
+++ b/app/views/conceptual_exams/form_batch.html.erb
@@ -1,0 +1,96 @@
+<% content_for :js do %>
+  <%= javascript_include_tag 'views/conceptual_exams/form_batch' %>
+<% end %>
+
+<div class="widget-body no-padding">
+  <table class="table table-bordered table-only-inner-bordered">
+    <thead>
+      <tr>
+        <th><%= ConceptualExam.human_attribute_name(:unity_id) %></th>
+        <th><%= ConceptualExam.human_attribute_name(:classroom) %></th>
+        <th><%= ConceptualExam.human_attribute_name(:step) %></th>
+        <th><%= ConceptualExam.human_attribute_name(:recorded_at) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= @classroom.unity.name %></td>
+        <td><%= @classroom.description %></td>
+        <td><%= @step.to_s %></td>
+        <td><%= l(@recorded_at) %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <%= form_tag create_batch_conceptual_exams_path, method: :post, class: 'smart-form', id: 'conceptual_exam_batch_form' do %>
+    <%= hidden_field_tag 'conceptual_exam_batch[unity_id]', @batch_form.unity_id %>
+    <%= hidden_field_tag 'conceptual_exam_batch[classroom_id]', @batch_form.classroom_id %>
+    <%= hidden_field_tag 'conceptual_exam_batch[step_id]', @batch_form.step_id %>
+    <%= hidden_field_tag 'conceptual_exam_batch[recorded_at]', @batch_form.recorded_at %>
+
+    <fieldset>
+      <legend><%= t('.legend') %></legend>
+
+      <div class="table-responsive">
+        <table class="table table-bordered table-only-inner-bordered table-striped table-condensed table-hover" id="conceptual_exam_batch_table">
+          <thead>
+            <tr>
+              <th style="min-width: 180px;"><%= Student.human_attribute_name(:name) %></th>
+              <% @disciplines.each do |discipline| %>
+                <th class="discipline-cell" title="<%= discipline.description %>"><%= discipline.description %></th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody>
+            <% @students.each do |student| %>
+              <tr data-student-id="<%= student.id %>">
+                <td><strong><%= student.name %></strong></td>
+                <% discipline_ids_for_student = @disciplines_by_student[student.id] || [] %>
+                <% exempted_ids = @exempted_by_student[student.id] || [] %>
+                <% existing_exam = @existing_by_student[student.id] %>
+                <% existing_values = existing_exam ? existing_exam.conceptual_exam_values.index_by(&:discipline_id) : {} %>
+                <% concept_options = concept_options_for_student(@classroom, student) %>
+
+                <% @disciplines.each do |discipline| %>
+                  <td class="concept-cell">
+                    <% if discipline_ids_for_student.include?(discipline.id) %>
+                      <% if exempted_ids.include?(discipline.id) %>
+                        <span class="text-muted"><%= t('.exempted') %></span>
+                      <% else %>
+                        <% existing_value = existing_values[discipline.id]&.value %>
+                        <%= select_tag "conceptual_exam_batch[students][#{student.id}][#{discipline.id}]",
+                              options_for_select(concept_options, existing_value),
+                              class: 'form-control input-sm concept-select',
+                              data: { student_id: student.id, discipline_id: discipline.id },
+                              include_blank: true %>
+                      <% end %>
+                    <% else %>
+                      <span class="text-muted">—</span>
+                    <% end %>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <tfoot class="exempted_students_from_discipline_legend">
+        <tr>
+          <td colspan="<%= @disciplines.count + 1 %>">
+            <span class="conceptual-exam-student-legend"><%= t('.exempted_legend') %></span>
+          </td>
+        </tr>
+      </tfoot>
+    </fieldset>
+
+    <footer>
+      <%= link_to t('views.form.back'), new_batch_conceptual_exams_path(conceptual_exam_batch: {
+            unity_id: @batch_form.unity_id,
+            classroom_id: @batch_form.classroom_id,
+            step_id: @batch_form.step_id
+          }), class: 'btn btn-default' %>
+      <%= submit_tag t('views.form.save'), class: 'btn btn-primary', data: { disable_with: 'Salvando...' } %>
+    </footer>
+  <% end %>
+</div>

--- a/app/views/conceptual_exams/index.html.erb
+++ b/app/views/conceptual_exams/index.html.erb
@@ -1,52 +1,56 @@
 <div class='widget-body no-padding'>
-  <%= simple_form_for :filter, { url: conceptual_exams_path, method: :get,
-    html: { class: 'filterable_search_form' } } do |f| %>
-    <div class='table-responsive'>
-      <table id='resources' class='table table-bordered table-only-inner-bordered table-striped table-condensed table-hover'>
-        <thead>
-          <tr>
-            <td></td>
-            <td></td>
-            <td>
-              <%= f.input :by_student_name, label: false, placeholder: t('.by_student_name') %>
-            </td>
-            <td>
-              <%= f.input :by_step, as: :select2_step, classroom: current_user_classroom,
-                label: false, placeholder: t('.by_step') %>
-            </td>
-            <td>
-              <%= f.input :by_status, as: :select2, elements: ConceptualExamStatus.to_select.to_json,
-                label: false, placeholder: t('.by_status') %>
-            </td>
-            <td>
-              <%= link_to t('.new_html'), new_conceptual_exam_path, class: 'btn btn-primary pull-right' %>
-            </td>
-          </tr>
+  <% if @conceptual_exam_batch_layout %>
+    <%= render 'index_batch_layout' %>
+  <% else %>
+    <%= simple_form_for :filter, { url: conceptual_exams_path, method: :get,
+      html: { class: 'filterable_search_form' } } do |f| %>
+      <div class='table-responsive'>
+        <table id='resources' class='table table-bordered table-only-inner-bordered table-striped table-condensed table-hover'>
+          <thead>
+            <tr>
+              <td></td>
+              <td></td>
+              <td>
+                <%= f.input :by_student_name, label: false, placeholder: t('.by_student_name') %>
+              </td>
+              <td>
+                <%= f.input :by_step, as: :select2_step, classroom: current_user_classroom,
+                  label: false, placeholder: t('.by_step') %>
+              </td>
+              <td>
+                <%= f.input :by_status, as: :select2, elements: ConceptualExamStatus.to_select.to_json,
+                  label: false, placeholder: t('.by_status') %>
+              </td>
+              <td>
+                <%= link_to t('.new_html'), new_conceptual_exam_path, class: 'btn btn-primary pull-right' %>
+              </td>
+            </tr>
 
-          <tr>
-            <th><%= ConceptualExam.human_attribute_name :unity_id %></th>
-            <th><%= ConceptualExam.human_attribute_name :classroom %></th>
-            <th><%= ConceptualExam.human_attribute_name :student %></th>
-            <th><%= ConceptualExam.human_attribute_name :step %></th>
-            <th><%= ConceptualExam.human_attribute_name :status %></th>
-            <td width='160px'></td>
-          </tr>
-        </thead>
+            <tr>
+              <th><%= ConceptualExam.human_attribute_name :unity_id %></th>
+              <th><%= ConceptualExam.human_attribute_name :classroom %></th>
+              <th><%= ConceptualExam.human_attribute_name :student %></th>
+              <th><%= ConceptualExam.human_attribute_name :step %></th>
+              <th><%= ConceptualExam.human_attribute_name :status %></th>
+              <td width='160px'></td>
+            </tr>
+          </thead>
 
-        <%= render 'resources' %>
+          <%= render 'resources' %>
 
-        <tfoot id='paginator' class='remote'>
-          <td colspan='7'>
-            <div id='page_entries_info' class='pull-left hidden-xs'>
-              <%= page_entries_info @conceptual_exams %>
-            </div>
+          <tfoot id='paginator' class='remote'>
+            <td colspan='7'>
+              <div id='page_entries_info' class='pull-left hidden-xs'>
+                <%= page_entries_info @conceptual_exams %>
+              </div>
 
-            <div class='pull-right'>
-              <%= paginate @conceptual_exams %>
-            </div>
-          </td>
-        </tfoot>
-      </table>
-    </div>
+              <div class='pull-right'>
+                <%= paginate @conceptual_exams %>
+              </div>
+            </td>
+          </tfoot>
+        </table>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/conceptual_exams/new_batch.html.erb
+++ b/app/views/conceptual_exams/new_batch.html.erb
@@ -1,0 +1,32 @@
+<div class="widget-body no-padding">
+  <% content_for :js do %>
+    <%= javascript_include_tag 'views/conceptual_exams/new_batch' %>
+  <% end %>
+
+  <%= simple_form_for @batch_form, as: :conceptual_exam_batch, url: form_batch_conceptual_exams_path, method: :get,
+                      html: { class: 'smart-form', id: 'conceptual_exam_batch_filter_form' } do |f| %>
+    <%= f.error_notification %>
+
+    <fieldset>
+      <legend><%= t('.legend') %></legend>
+      <div class="row">
+        <div class="col col-sm-4">
+          <%= f.input :unity_id, as: :select2_unity, user: current_user, label: Unity.human_attribute_name(:name) %>
+        </div>
+        <div class="col col-sm-4">
+          <%= f.input :classroom_id, as: :select2_classroom, user: current_user, record: @batch_form,
+                        elements: @classrooms.to_a, label: Classroom.human_attribute_name(:description) %>
+        </div>
+        <div class="col col-sm-4">
+          <%= f.input :step_id, as: :select2_step, classroom: current_user_classroom,
+                      label: ConceptualExam.human_attribute_name(:step), required: true %>
+        </div>
+      </div>
+    </fieldset>
+
+    <footer>
+      <%= link_to t('views.form.back'), conceptual_exams_path, class: 'btn btn-default' %>
+      <%= f.submit t('.continue'), class: 'btn btn-primary', data: { disable_with: 'Aguarde...' } %>
+    </footer>
+  <% end %>
+</div>

--- a/config/locales/controllers/conceptual_exams.yml
+++ b/config/locales/controllers/conceptual_exams.yml
@@ -2,3 +2,7 @@ pt-BR:
   conceptual_exams:
     new:
       current_discipline_does_not_have_conceptual_exam: 'A disciplina selecionada não possui nota conceitual'
+    batch:
+      not_available: 'O preenchimento por turma não está disponível para esta unidade.'
+    create_batch:
+      saved: '%{count} avaliação(ões) salva(s) com sucesso.'

--- a/config/locales/views/conceptual_exams.yml
+++ b/config/locales/views/conceptual_exams.yml
@@ -2,10 +2,25 @@ pt-BR:
   conceptual_exams:
     index:
       new_html: "<i class='fa fa-plus'></i> Novo lançamento"
+      new_batch_html: "<i class='fa fa-list'></i> Preencher por turma"
       by_classroom: 'Filtrar turma'
       by_student_name: 'Filtrar aluno'
       by_step: 'Filtrar etapa'
       by_status: 'Filtrar situação'
+      batch_layout_title: 'Lançamento por etapa'
+      batch_layout_subtitle: 'Selecione a etapa para preencher as avaliações conceituais de todos os alunos da turma.'
+      batch_layout_fill_button: 'Preencher / Editar'
+      batch_layout_no_steps: 'Nenhuma etapa encontrada para esta turma.'
+      batch_layout_classroom: 'Turma'
+
+    new_batch:
+      legend: 'Selecione a turma e a etapa'
+      continue: 'Continuar'
+
+    form_batch:
+      legend: 'Avaliações conceituais - todos os alunos'
+      exempted: 'Dispensado'
+      exempted_legend: '**** Disciplina dispensada para o aluno'
 
     form:
       save_and_go_to_the_next: 'Salvar e ir para o próximo'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -323,6 +323,9 @@ Rails.application.routes.draw do
         get :find_conceptual_exam_by_student
         get :find_step_number_by_classroom
         get :fetch_score_type
+        get :new_batch
+        get :form_batch
+        post :create_batch
       end
     end
     resources :old_steps_conceptual_values, except: [:only]

--- a/config/secrets.sample.yml
+++ b/config/secrets.sample.yml
@@ -16,4 +16,7 @@ development:
   REDIS_DB_SIDEKIQ: REDIS_DB_SIDEKIQ
   shortcuts_enabled: true
   only_one_conceptual_avaliation: true
+  # Layout por turma: preencher avaliações conceituais de todos os alunos de uma vez (matriz).
+  # Quando true, o índice exibe "Preencher por turma" e usa new_batch/form_batch/create_batch.
+  conceptual_exam_batch_layout: false
   show_objectives: true

--- a/script/start
+++ b/script/start
@@ -12,7 +12,8 @@ if ! test -f ".setup"; then
     shortcuts_enabled: true
     only_one_conceptual_avaliation: false
     show_objectives: true
-    SEMESTRAL_RECOVERY: false
+    SEMESTRAL_RECOVERY: true
+    conceptual_exam_batch_layout: true
     " > config/secrets.yml
 
   cp config/database.sample.yml config/database.yml


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new bulk create/update paths for student assessment data and relaxes strong params for a nested `students` hash, which increases the chance of data integrity/authorization edge cases if not thoroughly tested.
> 
> **Overview**
> Adds a **feature-flagged “batch layout”** for conceptual exams that lets teachers fill/edit concept grades for *all students in a classroom for a selected step* via a matrix-style form.
> 
> When `secrets.conceptual_exam_batch_layout` is enabled, `ConceptualExamsController#index` switches to a step-selection index and introduces `new_batch`, `form_batch`, and `create_batch` endpoints to validate inputs, preload students/disciplines/exemptions/existing values, and upsert one `ConceptualExam` per student (handling the `only_one_conceptual_avaliation` mode and recorded-at day validation).
> 
> Includes new `ConceptualExamBatchForm`, `ConceptualExamPolicy` permissions, helper for per-student concept options, Select2 UI JS, routes, views, and i18n/secrets sample updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72ce8655fb3b93cb1be5b902393b8b2f4da0ca89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->