### PR TITLE
relatório conceitual

### DIFF
--- a/app/assets/javascripts/views/conceptual_exam_report/form.js
+++ b/app/assets/javascripts/views/conceptual_exam_report/form.js
@@ -1,0 +1,39 @@
+$(function () {
+  'use strict';
+
+  var $classroom = $('#conceptual_exam_report_form_classroom_id');
+  var $step = $('#conceptual_exam_report_form_step_id');
+  var flashMessages = new FlashMessages();
+
+  $classroom.on('change', function () {
+    getStep();
+  });
+
+  function getStep() {
+    var classroom_id = $classroom.select2('val');
+    if (!_.isEmpty(classroom_id)) {
+      $.ajax({
+        url: Routes.fetch_step_conceptual_exam_report_path({
+          classroom_id: classroom_id,
+          format: 'json'
+        }),
+        success: handleFetchStepByClassroomSuccess,
+        error: handleFetchStepByClassroomError
+      });
+    }
+  }
+
+  function handleFetchStepByClassroomSuccess(data) {
+    var selectedSteps = data.map(function (step) {
+      return { id: step.id, text: step.description, start_at: step.start_at, end_at: step.end_at };
+    });
+    $step.select2({ data: selectedSteps });
+    if (selectedSteps.length > 0) {
+      $step.val(selectedSteps[0].id).trigger('change');
+    }
+  }
+
+  function handleFetchStepByClassroomError() {
+    flashMessages.error('Ocorreu um erro ao buscar a etapa da turma.');
+  }
+});

--- a/app/controllers/conceptual_exam_report_controller.rb
+++ b/app/controllers/conceptual_exam_report_controller.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+class ConceptualExamReportController < ApplicationController
+  before_action :require_current_classroom
+  before_action :require_current_teacher
+  before_action :require_conceptual_exam_report_enabled, only: [:form, :report, :fetch_step]
+
+  def form
+    set_options_by_user
+    @classroom = current_user_classroom
+    @steps = @classroom.present? ? steps_fetcher(@classroom).steps : []
+    @conceptual_exam_report_form = ConceptualExamReportForm.new(
+      unity_id: current_unity.id,
+      classroom_id: @classroom&.id,
+      step_id: @steps.first&.id
+    )
+  end
+
+  def fetch_step
+    return if params[:classroom_id].blank?
+
+    classroom = Classroom.find(params[:classroom_id])
+    steps = StepsFetcher.new(classroom)&.steps || []
+    steps_json = steps.map { |step| { id: step.id, description: step.to_s, start_at: step.start_at, end_at: step.end_at } }
+    render json: steps_json
+  end
+
+  def report
+    set_options_by_user
+    @conceptual_exam_report_form = ConceptualExamReportForm.new(report_params)
+
+    if @conceptual_exam_report_form.valid?
+      classroom = Classroom.find(@conceptual_exam_report_form.classroom_id)
+      step = StepsFetcher.new(classroom).step_by_id(@conceptual_exam_report_form.step_id)
+
+      students = fetch_report_students(classroom, step)
+      disciplines = fetch_report_disciplines(classroom, students, step)
+      conceptual_exams_by_student = fetch_conceptual_exams_for_report(classroom, step, students)
+
+      pdf_report = ConceptualExamReport.build(
+        current_entity_configuration,
+        current_unity,
+        classroom,
+        step,
+        students,
+        disciplines,
+        conceptual_exams_by_student
+      )
+
+      send_pdf(t('conceptual_exam_report.title'), pdf_report.render)
+    else
+      @classroom = Classroom.find_by(id: @conceptual_exam_report_form.classroom_id)
+      @steps = @classroom.present? ? steps_fetcher(@classroom).steps : []
+      render :form
+    end
+  end
+
+  private
+
+  def set_options_by_user
+    @unities = [current_user_unity]
+    fetch_linked_by_teacher
+  end
+
+  def fetch_linked_by_teacher
+    @fetch_linked_by_teacher ||= TeacherClassroomAndDisciplineFetcher.fetch!(
+      current_teacher.id,
+      current_unity,
+      current_school_year,
+      current_user_classroom
+    )
+    @classrooms ||= @fetch_linked_by_teacher[:classrooms]
+  end
+
+  def report_params
+    params.require(:conceptual_exam_report_form).permit(:unity_id, :classroom_id, :step_id)
+  end
+
+  def require_conceptual_exam_report_enabled
+    return if conceptual_exam_report_enabled?
+
+    redirect_to conceptual_exams_path, alert: t('conceptual_exam_report.not_available')
+  end
+
+  def conceptual_exam_report_enabled?
+    Rails.application.secrets.conceptual_exam_batch_layout.present? &&
+      Rails.application.secrets.conceptual_exam_batch_layout
+  end
+
+  def steps_fetcher(classroom)
+    StepsFetcher.new(classroom)
+  end
+
+  def fetch_report_students(classroom, step)
+    student_ids = StudentEnrollmentClassroom
+      .by_classroom(classroom.id)
+      .by_date_range(step.start_at, step.end_at)
+      .by_score_type(StudentEnrollmentScoreTypeFilters::CONCEPT, classroom.id)
+      .active
+      .joins(student_enrollment: :student)
+      .merge(StudentEnrollment.status_attending)
+      .pluck('students.id')
+      .uniq
+    Student.where(id: student_ids).ordered
+  end
+
+  def fetch_report_disciplines(classroom, students, step)
+    school_calendar = SchoolCalendar.find_by(unity_id: classroom.unity_id, year: classroom.year)
+    return Discipline.none if school_calendar.blank?
+
+    teacher_discipline_ids = TeacherDisciplineClassroom
+      .by_classroom(classroom.id)
+      .by_teacher_id(current_teacher_id)
+      .by_year(current_school_calendar.year)
+      .pluck(:discipline_id)
+      .uniq
+
+    step_number = step.respond_to?(:to_number) ? step.to_number : step.step_number
+    exempted_discipline_ids = ExemptedDisciplinesInStep.discipline_ids(classroom.id, step_number)
+    discipline_ids_global = Discipline
+      .where(id: teacher_discipline_ids)
+      .by_score_type(ScoreTypes::CONCEPT)
+      .not_grouper
+      .descriptor
+      .where.not(id: exempted_discipline_ids)
+      .pluck(:id)
+
+    result_ids = []
+    students.each do |student|
+      cg = ClassroomsGrade.by_student_id(student.id).by_classroom_id(classroom.id).first
+      next if cg.blank?
+
+      grade_discipline_ids = SchoolCalendarDisciplineGrade
+        .where(school_calendar_id: school_calendar.id, grade_id: cg.grade_id)
+        .pluck(:discipline_id)
+      result_ids = (result_ids + (discipline_ids_global & grade_discipline_ids)).uniq
+    end
+    Discipline.where(id: result_ids).includes(:knowledge_area).to_a.sort_by { |d| [d.knowledge_area&.sequence.to_i, d.knowledge_area&.description.to_s, d.sequence.to_i, d.description] }
+  end
+
+  def fetch_conceptual_exams_for_report(classroom, step, students)
+    conceptual_exams = ConceptualExam
+      .by_classroom(classroom.id)
+      .by_step_number(step.step_number)
+      .where(student_id: students.map(&:id))
+      .includes(:conceptual_exam_values)
+
+    conceptual_exams.index_by(&:student_id)
+  end
+end

--- a/app/forms/conceptual_exam_report_form.rb
+++ b/app/forms/conceptual_exam_report_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ConceptualExamReportForm
+  include ActiveModel::Model
+
+  attr_accessor :unity_id, :classroom_id, :step_id
+
+  validates :unity_id, presence: true
+  validates :classroom_id, presence: true
+  validates :step_id, presence: true
+
+  def classroom
+    @classroom ||= Classroom.find_by(id: classroom_id)
+  end
+
+  def step
+    return if step_id.blank? || classroom.blank?
+
+    @step ||= StepsFetcher.new(classroom).step_by_id(step_id)
+  end
+end

--- a/app/reports/conceptual_exam_report.rb
+++ b/app/reports/conceptual_exam_report.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+class ConceptualExamReport < BaseReport
+  def self.build(entity_configuration, unity, classroom, step, students, disciplines, conceptual_exams_by_student)
+    new.build(entity_configuration, unity, classroom, step, students, disciplines, conceptual_exams_by_student)
+  end
+
+  def build(entity_configuration, unity, classroom, step, students, disciplines, conceptual_exams_by_student)
+    @entity_configuration = entity_configuration
+    @unity = unity
+    @classroom = classroom
+    @step = step
+    @students = students
+    @disciplines = disciplines
+    @conceptual_exams_by_student = conceptual_exams_by_student || {}
+
+    header
+    body
+    footer
+
+    self
+  end
+
+  private
+
+  def header
+    title = make_cell(
+      content: I18n.t('conceptual_exam_report.pdf_title'),
+      size: 12,
+      font_style: :bold,
+      background_color: 'DEDEDE',
+      height: 20,
+      padding: [2, 2, 4, 4],
+      align: :center,
+      colspan: @disciplines.size + 1
+    )
+    begin
+      logo_cell = make_cell(image: open(@entity_configuration.logo.url), fit: [50, 50], width: 70, rowspan: 3, position: :center, vposition: :center)
+    rescue
+      logo_cell = make_cell(content: '', width: 70, rowspan: 3)
+    end
+
+    entity_name = @entity_configuration&.entity_name || ''
+    organ_name = @entity_configuration&.organ_name || ''
+    entity_organ_unity = make_cell(
+      content: "#{entity_name}\n#{organ_name}\n#{@unity.name}",
+      size: 10,
+      leading: 1.5,
+      align: :center,
+      valign: :center,
+      rowspan: 3,
+      padding: [4, 2, 8, 2]
+    )
+
+    step_cell = make_cell(
+      content: "#{ConceptualExam.human_attribute_name(:classroom)}: #{@classroom.description} | #{ConceptualExam.human_attribute_name(:step)}: #{@step.to_s}",
+      size: 10,
+      colspan: [@disciplines.size, 1].max,
+      padding: [2, 2, 4, 4]
+    )
+
+    header_data = [[title], [logo_cell, entity_organ_unity, step_cell]]
+
+    page_header do
+      table(header_data, width: bounds.width) do
+        cells.border_width = 0.25
+      end
+      move_down 8
+    end
+  end
+
+  def body
+    page_content do
+      return if @students.blank?
+
+      num_cols = [@disciplines.size, 1].max
+      col_widths = [bounds.width * 0.35] + Array.new(@disciplines.size) { (bounds.width * 0.65) / num_cols }
+
+      # Cabeçalho da tabela: Aluno | Disciplina 1 | Disciplina 2 | ...
+      header_cells = [
+        make_cell(content: Student.human_attribute_name(:name), size: 8, font_style: :bold, background_color: 'E8E8E8', padding: [4, 2])
+      ]
+      @disciplines.each do |d|
+        header_cells << make_cell(content: d.description.to_s.truncate(20), size: 7, font_style: :bold, background_color: 'E8E8E8', padding: [4, 2])
+      end
+      table_data = [header_cells]
+
+      @students.each do |student|
+        conceptual_exam = @conceptual_exams_by_student[student.id]
+        values_by_discipline = conceptual_exam ? conceptual_exam.conceptual_exam_values.index_by(&:discipline_id) : {}
+
+        row_cells = [
+          make_cell(content: student.name.to_s.truncate(35), size: 8, padding: [3, 2])
+        ]
+        @disciplines.each do |discipline|
+          value_record = values_by_discipline[discipline.id]
+          raw_value = value_record&.value
+          cell_content = concept_display_name(@classroom, student, raw_value)
+          row_cells << make_cell(content: cell_content.to_s, size: 8, padding: [3, 2])
+        end
+        table_data << row_cells
+      end
+
+      table(table_data, width: bounds.width, column_widths: col_widths, cell_style: { border_width: 0.25 }) do
+        row(0).font_style = :bold
+      end
+    end
+  end
+
+  def footer
+    page_footer(draw_datetime: true)
+  end
+
+  def concept_display_name(classroom, student, value)
+    return '-' if value.blank?
+
+    exam_rule = ExamRuleFetcher.fetch(classroom, student)
+    rounding_table = exam_rule&.conceptual_rounding_table
+    return value.to_s if rounding_table.blank?
+
+    rtv = rounding_table.rounding_table_values.find { |v| v.value.to_s == value.to_s }
+    rtv ? rtv.label.to_s : value.to_s
+  end
+end

--- a/app/views/conceptual_exam_report/form.html.erb
+++ b/app/views/conceptual_exam_report/form.html.erb
@@ -1,0 +1,33 @@
+<% content_for :js do %>
+  <%= javascript_include_tag 'views/conceptual_exam_report/form' %>
+<% end %>
+
+<div class="widget-body no-padding">
+  <%= simple_form_for @conceptual_exam_report_form, as: :conceptual_exam_report_form,
+                      url: conceptual_exam_report_report_path, method: :post,
+                      html: { class: 'smart-form', target: '_blank', id: 'conceptual_exam_report_form' } do |f| %>
+    <%= f.error_notification %>
+
+    <fieldset>
+      <legend><%= t('conceptual_exam_report.form.legend') %></legend>
+      <div class="row">
+        <div class="col col-sm-4">
+          <%= f.input :unity_id, as: :select2_unity, user: current_user, label: t('conceptual_exam_report.form.unity') %>
+        </div>
+        <div class="col col-sm-4">
+          <%= f.input :classroom_id, as: :select2_classroom, user: current_user, record: @conceptual_exam_report_form,
+                        elements: @classrooms.to_a, label: t('conceptual_exam_report.form.classroom'), required: true %>
+        </div>
+        <div class="col col-sm-4">
+          <%= f.input :step_id, as: :select2_step, classroom: @classroom,
+                      label: t('conceptual_exam_report.form.step'), required: true %>
+        </div>
+      </div>
+    </fieldset>
+
+    <footer>
+      <%= link_to t('views.form.back'), conceptual_exams_path, class: 'btn btn-default' %>
+      <%= f.submit t('conceptual_exam_report.form.generate'), class: 'btn btn-primary', data: { disable_with: 'Aguarde...' } %>
+    </footer>
+  <% end %>
+</div>

--- a/app/views/conceptual_exams/_index_batch_layout.html.erb
+++ b/app/views/conceptual_exams/_index_batch_layout.html.erb
@@ -20,14 +20,24 @@
                 <%= l(step.start_at) %> a <%= l(step.end_at) %>
               </p>
             </div>
-            <div class="col-sm-4 col-md-3 text-right">
-              <%= link_to form_batch_conceptual_exams_path(conceptual_exam_batch: {
-                    unity_id: @classroom.unity_id,
-                    classroom_id: @classroom.id,
-                    step_id: step.id
-                  }), class: 'btn btn-primary' do %>
-                <i class='fa fa-edit'></i> <%= t('conceptual_exams.index.batch_layout_fill_button') %>
-              <% end %>
+            <div class="col-sm-4 col-md-3">
+              <div class="pull-right">
+                <%= link_to form_batch_conceptual_exams_path(conceptual_exam_batch: {
+                      unity_id: @classroom.unity_id,
+                      classroom_id: @classroom.id,
+                      step_id: step.id
+                    }), class: 'btn btn-primary' do %>
+                  <i class='fa fa-edit'></i> <%= t('conceptual_exams.index.batch_layout_fill_button') %>
+                <% end %>
+                <%= form_tag conceptual_exam_report_report_path, method: :post, target: '_blank', style: 'display: inline; margin-left: 8px;' do %>
+                  <%= hidden_field_tag 'conceptual_exam_report_form[unity_id]', @classroom.unity_id %>
+                  <%= hidden_field_tag 'conceptual_exam_report_form[classroom_id]', @classroom.id %>
+                  <%= hidden_field_tag 'conceptual_exam_report_form[step_id]', step.id %>
+                  <%= button_tag type: 'submit', class: 'btn btn-default' do %>
+                    <i class='fa fa-file-pdf-o'></i> <%= t('conceptual_exam_report.form.generate') %> relatório
+                  <% end %>
+                <% end %>
+              </div>
             </div>
           </div>
         </div>

--- a/config/locales/conceptual_exam_report.yml
+++ b/config/locales/conceptual_exam_report.yml
@@ -1,0 +1,11 @@
+pt-BR:
+  conceptual_exam_report:
+    title: 'Relatório de avaliação conceitual'
+    not_available: 'Relatório de avaliação conceitual não disponível para esta configuração.'
+    pdf_title: 'Relatório de avaliação conceitual'
+    form:
+      legend: 'Selecione a turma e a etapa'
+      generate: 'Gerar'
+      unity: 'Unidade'
+      classroom: 'Turma'
+      step: 'Etapa'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -453,6 +453,10 @@ Rails.application.routes.draw do
     get '/reports/knowledge_area_lesson_plan/fetch_knowledge_areas', to: 'knowledge_area_lesson_plan_report#fetch_knowledge_areas', as: 'fetch_knowledge_areas_knowledge_area_lesson_plan_report'
     post '/reports/knowledge_area_content_record', to: 'knowledge_area_lesson_plan_report#content_record_report', as: 'knowledge_area_content_record_report'
 
+    get '/reports/conceptual_exam', to: 'conceptual_exam_report#form', as: 'conceptual_exam_report'
+    get '/reports/conceptual_exam/fetch_step', to: 'conceptual_exam_report#fetch_step', as: 'fetch_step_conceptual_exam_report'
+    post '/reports/conceptual_exam', to: 'conceptual_exam_report#report', as: 'conceptual_exam_report_report'
+
     get '/reports/teacher_report_cards', to: 'teacher_report_cards#form', as: 'teacher_report_cards'
     get '/reports/teacher_report_cards/set_grades_by_classroom', to: 'teacher_report_cards#set_grades_by_classroom', as: 'grade_teacher_report_cards'
     get '/reports/teacher_report_cards/classrooms_filter', to: 'teacher_report_cards#classrooms_filter', as: 'classrooms_filter_teacher_report_cards'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new reporting endpoints and PDF generation with multiple DB queries and data joins; main risks are performance and correctness of filtering by step/classroom and discipline selection.
> 
> **Overview**
> Adds a new **Conceptual Exam Report** flow: a new controller (`ConceptualExamReportController`) with `form`, `fetch_step` (AJAX), and `report` actions plus new routes under `/reports/conceptual_exam`.
> 
> Introduces `ConceptualExamReportForm` validation and a new `ConceptualExamReport` PDF builder that renders a per-student/per-discipline table using conceptual exam values (including rounding-table label mapping), along with a new form view + JS to reload available steps when the classroom changes.
> 
> Updates the conceptual exams batch index to include a one-click "Gerar relatório" PDF button for each step, and adds i18n strings for the new report.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 539cbfa743f096e412f6ca1b857e4d0f3184c43f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->